### PR TITLE
bug(web): fix calendar date navigation between sidebar and main view

### DIFF
--- a/apps/web/src/components/calendar-layout.tsx
+++ b/apps/web/src/components/calendar-layout.tsx
@@ -3,14 +3,17 @@
 import { AppSidebar } from "@/components/app-sidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { CalendarView } from "./calendar-view";
+import { CalendarProvider } from "@/contexts/calendar-context";
 
 export function CalendarLayout() {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset>
-        <CalendarView className="grow" />
-      </SidebarInset>
-    </SidebarProvider>
+    <CalendarProvider>
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          <CalendarView className="grow" />
+        </SidebarInset>
+      </SidebarProvider>
+    </CalendarProvider>
   );
 }

--- a/apps/web/src/components/date-picker.tsx
+++ b/apps/web/src/components/date-picker.tsx
@@ -3,15 +3,19 @@
 import { Calendar } from "@/components/ui/calendar";
 import { SidebarGroup, SidebarGroupContent } from "@/components/ui/sidebar";
 import { useCalendarContext } from "@/contexts/calendar-context";
+import { useCallback } from "react";
 
 export function DatePicker() {
   const { currentDate, setCurrentDate } = useCalendarContext();
 
-  const handleDateSelect = (date: Date | undefined) => {
-    if (date) {
-      setCurrentDate(date);
-    }
-  };
+  const handleDateSelect = useCallback(
+    (date: Date | undefined) => {
+      if (date) {
+        setCurrentDate(date);
+      }
+    },
+    [setCurrentDate]
+  );
 
   return (
     <SidebarGroup className="px-0">

--- a/apps/web/src/components/date-picker.tsx
+++ b/apps/web/src/components/date-picker.tsx
@@ -1,11 +1,33 @@
+"use client";
+
 import { Calendar } from "@/components/ui/calendar";
 import { SidebarGroup, SidebarGroupContent } from "@/components/ui/sidebar";
+import { useCalendarContext } from "@/contexts/calendar-context";
 
 export function DatePicker() {
+  const { currentDate, setCurrentDate } = useCalendarContext();
+
+  const handleDateSelect = (date: Date | undefined) => {
+    if (date) {
+      setCurrentDate(date);
+    }
+  };
+
   return (
     <SidebarGroup className="px-0">
       <SidebarGroupContent>
-        <Calendar className="[&_[role=gridcell].bg-accent]:bg-sidebar-primary [&_[role=gridcell].bg-accent]:text-sidebar-primary-foreground [&_[role=gridcell]]:w-[33px]" />
+        <Calendar
+          mode="single"
+          selected={currentDate}
+          onSelect={handleDateSelect}
+          className="[&_[role=gridcell]]:w-[33px]"
+          classNames={{
+            day_selected:
+              "bg-sidebar-primary text-sidebar-primary-foreground hover:!bg-sidebar-primary hover:!text-sidebar-primary-foreground hover:filter hover:brightness-[0.8] focus:bg-sidebar-primary focus:text-sidebar-primary-foreground",
+            day_today:
+              "border-1 border-accent-foreground/50 bg-transparent font-medium hover:opacity-80 aria-selected:border-0",
+          }}
+        />
       </SidebarGroupContent>
     </SidebarGroup>
   );

--- a/apps/web/src/components/date-picker.tsx
+++ b/apps/web/src/components/date-picker.tsx
@@ -23,9 +23,9 @@ export function DatePicker() {
           className="[&_[role=gridcell]]:w-[33px]"
           classNames={{
             day_selected:
-              "bg-sidebar-primary text-sidebar-primary-foreground hover:!bg-sidebar-primary hover:!text-sidebar-primary-foreground hover:filter hover:brightness-[0.8] focus:bg-sidebar-primary focus:text-sidebar-primary-foreground",
+              "!bg-sidebar-primary !text-sidebar-primary-foreground hover:!bg-sidebar-primary hover:!text-sidebar-primary-foreground hover:filter hover:brightness-[0.8] focus:!bg-sidebar-primary focus:!text-sidebar-primary-foreground",
             day_today:
-              "border-1 border-accent-foreground/50 bg-transparent font-medium hover:opacity-80 aria-selected:border-0",
+              "!border-1 !border-sidebar-primary/30 dark:!border-sidebar-primary/70 font-medium hover:opacity-80 aria-selected:!border-0 aria-selected:!bg-sidebar-primary",
           }}
         />
       </SidebarGroupContent>

--- a/apps/web/src/components/event-calendar/event-calendar.tsx
+++ b/apps/web/src/components/event-calendar/event-calendar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useCalendarContextOptional } from "@/contexts/calendar-context";
 import { RiCalendarCheckLine } from "@remixicon/react";
 import {
   addDays,
@@ -64,11 +65,18 @@ export function EventCalendar({
   className,
   initialView = "week",
 }: EventCalendarProps) {
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const [view, setView] = useState<CalendarView>(initialView);
+  // Use context if available, otherwise use local state
+  const context = useCalendarContextOptional();
+  const [localCurrentDate, setLocalCurrentDate] = useState(new Date());
+  const [localView, setLocalView] = useState<CalendarView>(initialView);
+
+  const currentDate = context?.currentDate ?? localCurrentDate;
+  const setCurrentDate = context?.setCurrentDate ?? setLocalCurrentDate;
+  const view = context?.view ?? localView;
+  const setView = context?.setView ?? setLocalView;
   const [isEventDialogOpen, setIsEventDialogOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(
-    null,
+    null
   );
 
   // Add keyboard shortcuts for view switching
@@ -106,7 +114,7 @@ export function EventCalendar({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isEventDialogOpen]);
+  }, [isEventDialogOpen, setView]);
 
   const handlePrevious = () => {
     if (view === "month") {
@@ -265,7 +273,7 @@ export function EventCalendar({
     <div
       className={cn(
         "flex flex-col has-data-[slot=month-view]:flex-1 overflow-scroll",
-        className,
+        className
       )}
       style={
         {
@@ -278,7 +286,7 @@ export function EventCalendar({
       <CalendarDndProvider onEventUpdate={handleEventUpdate}>
         <header
           className={cn(
-            "flex items-center justify-between p-2 sm:p-4 h-16 gap-2 border-b px-4",
+            "flex items-center justify-between p-2 sm:p-4 h-16 gap-2 border-b px-4"
           )}
         >
           <div className="flex items-center gap-1 sm:gap-4">

--- a/apps/web/src/contexts/calendar-context.tsx
+++ b/apps/web/src/contexts/calendar-context.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React, { createContext, useContext } from "react";
+import { CalendarView } from "@/components/event-calendar";
+import { useCalendarState } from "@/hooks/use-calendar-state";
+
+interface CalendarContextType {
+  currentDate: Date;
+  setCurrentDate: (date: Date) => void;
+  view: CalendarView;
+  setView: (view: CalendarView) => void;
+}
+
+const CalendarContext = createContext<CalendarContextType | undefined>(
+  undefined
+);
+
+export function CalendarProvider({
+  children,
+  initialView = "week",
+}: {
+  children: React.ReactNode;
+  initialView?: CalendarView;
+}) {
+  const calendarState = useCalendarState(initialView);
+
+  return (
+    <CalendarContext.Provider value={calendarState}>
+      {children}
+    </CalendarContext.Provider>
+  );
+}
+
+export function useCalendarContext() {
+  const context = useContext(CalendarContext);
+  if (context === undefined) {
+    throw new Error(
+      "useCalendarContext must be used within a CalendarProvider"
+    );
+  }
+  return context;
+}
+
+export function useCalendarContextOptional() {
+  return useContext(CalendarContext);
+}

--- a/apps/web/src/hooks/use-calendar-state.ts
+++ b/apps/web/src/hooks/use-calendar-state.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarView } from "@/components/event-calendar";
+
+export function useCalendarState(initialView: CalendarView = "week") {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [view, setView] = useState<CalendarView>(initialView);
+
+  return {
+    currentDate,
+    setCurrentDate,
+    view,
+    setView,
+  };
+}


### PR DESCRIPTION

## Fix calendar date navigation between sidebar and main view

### Problem
Clicking dates in the sidebar calendar didn't update the main calendar view. The two components weren't connected.

### Solution
- Added shared state management using React Context
- Connected sidebar DatePicker to main EventCalendar component
- Improved visual styling to distinguish between current day (border) and selected day (filled background)

### Result
Now when you click a date in the sidebar, the main calendar navigates to that date. Much better user experience.


<img width="319" alt="Screenshot 2025-05-24 at 03 40 00" src="https://github.com/user-attachments/assets/7294ecd5-0ceb-4d05-9e31-c42da85e3227" />
