### PR TITLE
refactor: rename repo packages to `@analog`

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/next";
+import { config } from "@analog/eslint-config/next";
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/web",
+  "name": "@analog/web",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -27,9 +27,9 @@
     "@remixicon/react": "^4.6.0",
     "@hookform/resolvers": "^5.0.1",
     "@number-flow/react": "^0.5.9",
-    "@repo/api": "workspace:*",
-    "@repo/auth": "workspace:*",
-    "@repo/env": "workspace:*",
+    "@analog/api": "workspace:*",
+    "@analog/auth": "workspace:*",
+    "@analog/env": "workspace:*",
     "@tanstack/react-query": "^5.76.1",
     "@trpc/client": "^11.1.2",
     "@trpc/server": "^11.1.2",
@@ -52,8 +52,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "@analog/eslint-config": "workspace:*",
+    "@analog/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { auth } from "@repo/auth/server";
+import { auth } from "@analog/auth/server";
 import { SignInForm } from "./sign-in-form";
 
 export const metadata: Metadata = {

--- a/apps/web/src/app/(auth)/login/sign-in-form.tsx
+++ b/apps/web/src/app/(auth)/login/sign-in-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { authClient } from "@repo/auth/client";
+import { authClient } from "@analog/auth/client";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,4 @@
 import { toNextJsHandler } from "better-auth/next-js";
-import { auth } from "@repo/auth/server";
+import { auth } from "@analog/auth/server";
 
 export const { POST, GET } = toNextJsHandler(auth);

--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
-import { appRouter, createContext } from "@repo/api";
-import { env } from "@repo/env/server";
+import { appRouter, createContext } from "@analog/api";
+import { env } from "@analog/env/server";
 
 const handler = (req: NextRequest) =>
   fetchRequestHandler({

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { auth } from "@repo/auth/server";
+import { auth } from "@analog/auth/server";
 import { CalendarLayout } from "@/components/calendar-layout";
 
 export default async function Page() {

--- a/apps/web/src/lib/trpc/client.tsx
+++ b/apps/web/src/lib/trpc/client.tsx
@@ -9,8 +9,8 @@ import {
 } from "@trpc/client";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
 import superjson from "superjson";
-import type { AppRouter } from "@repo/api";
-import { env } from "@repo/env/client";
+import type { AppRouter } from "@analog/api";
+import { env } from "@analog/env/client";
 import { getQueryClient } from "./query-client";
 
 export const { TRPCProvider, useTRPC } = createTRPCContext<AppRouter>();

--- a/apps/web/src/lib/trpc/index.ts
+++ b/apps/web/src/lib/trpc/index.ts
@@ -1,5 +1,5 @@
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
-import type { AppRouter } from "@repo/api";
+import type { AppRouter } from "@analog/api";
 
 export type RouterInputs = inferRouterInputs<AppRouter>;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;

--- a/apps/web/src/lib/trpc/server.tsx
+++ b/apps/web/src/lib/trpc/server.tsx
@@ -5,7 +5,7 @@ import {
   createTRPCOptionsProxy,
   TRPCQueryOptions,
 } from "@trpc/tanstack-react-query";
-import { appRouter, createContext } from "@repo/api";
+import { appRouter, createContext } from "@analog/api";
 import { makeQueryClient } from "./query-client";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/next.json",
+  "extends": "@analog/typescript-config/next.json",
   "compilerOptions": {
     "plugins": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -10,9 +10,12 @@
       },
     },
     "apps/web": {
-      "name": "@repo/web",
+      "name": "@analog/web",
       "version": "0.1.0",
       "dependencies": {
+        "@analog/api": "workspace:*",
+        "@analog/auth": "workspace:*",
+        "@analog/env": "workspace:*",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -31,9 +34,6 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.6",
         "@remixicon/react": "^4.6.0",
-        "@repo/api": "workspace:*",
-        "@repo/auth": "workspace:*",
-        "@repo/env": "workspace:*",
         "@tanstack/react-query": "^5.76.1",
         "@trpc/client": "^11.1.2",
         "@trpc/server": "^11.1.2",
@@ -55,9 +55,9 @@
         "tw-animate-css": "^1.3.0",
       },
       "devDependencies": {
+        "@analog/eslint-config": "workspace:*",
+        "@analog/typescript-config": "workspace:*",
         "@eslint/eslintrc": "^3",
-        "@repo/eslint-config": "workspace:*",
-        "@repo/typescript-config": "workspace:*",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -69,17 +69,17 @@
       },
     },
     "packages/api": {
-      "name": "@repo/api",
+      "name": "@analog/api",
       "version": "0.1.0",
       "dependencies": {
-        "@repo/auth": "workspace:*",
-        "@repo/db": "workspace:*",
-        "@repo/env": "workspace:*",
-        "@repo/google-calendar": "workspace:*",
+        "@analog/auth": "workspace:*",
+        "@analog/db": "workspace:*",
+        "@analog/env": "workspace:*",
+        "@analog/google-calendar": "workspace:*",
       },
       "devDependencies": {
-        "@repo/eslint-config": "workspace:*",
-        "@repo/typescript-config": "workspace:*",
+        "@analog/eslint-config": "workspace:*",
+        "@analog/typescript-config": "workspace:*",
         "@types/node": "^20",
         "eslint": "^9",
         "typescript": "^5",
@@ -94,15 +94,15 @@
       },
     },
     "packages/auth": {
-      "name": "@repo/auth",
+      "name": "@analog/auth",
       "version": "0.1.0",
       "dependencies": {
-        "@repo/db": "workspace:*",
-        "@repo/env": "workspace:*",
+        "@analog/db": "workspace:*",
+        "@analog/env": "workspace:*",
       },
       "devDependencies": {
-        "@repo/eslint-config": "workspace:*",
-        "@repo/typescript-config": "workspace:*",
+        "@analog/eslint-config": "workspace:*",
+        "@analog/typescript-config": "workspace:*",
         "@types/node": "^20",
         "eslint": "^9",
         "typescript": "^5",
@@ -113,17 +113,17 @@
       },
     },
     "packages/db": {
-      "name": "@repo/db",
+      "name": "@analog/db",
       "version": "0.1.0",
       "dependencies": {
-        "@repo/env": "workspace:*",
+        "@analog/env": "workspace:*",
         "drizzle-orm": "^0.43.1",
         "postgres": "^3.4.5",
         "server-only": "^0.0.1",
       },
       "devDependencies": {
-        "@repo/eslint-config": "workspace:*",
-        "@repo/typescript-config": "workspace:*",
+        "@analog/eslint-config": "workspace:*",
+        "@analog/typescript-config": "workspace:*",
         "@types/node": "^20",
         "drizzle-kit": "^0.31.1",
         "eslint": "^9",
@@ -131,31 +131,31 @@
       },
     },
     "packages/env": {
-      "name": "@repo/env",
+      "name": "@analog/env",
       "version": "0.1.0",
       "dependencies": {
         "@t3-oss/env-nextjs": "^0.13.4",
         "zod": "^3.24.4",
       },
       "devDependencies": {
-        "@repo/eslint-config": "workspace:*",
-        "@repo/typescript-config": "workspace:*",
+        "@analog/eslint-config": "workspace:*",
+        "@analog/typescript-config": "workspace:*",
         "@types/node": "^20",
         "eslint": "^9",
         "typescript": "^5",
       },
     },
     "packages/google-calendar": {
-      "name": "@repo/google-calendar",
+      "name": "@analog/google-calendar",
       "version": "0.0.1-alpha.0",
       "devDependencies": {
-        "@repo/typescript-config": "workspace:*",
+        "@analog/typescript-config": "workspace:*",
         "@types/node": "^20",
         "typescript": "^5",
       },
     },
     "tooling/eslint-config": {
-      "name": "@repo/eslint-config",
+      "name": "@analog/eslint-config",
       "version": "0.0.0",
       "devDependencies": {
         "@eslint/js": "^9.26.0",
@@ -172,7 +172,7 @@
       },
     },
     "tooling/typescript-config": {
-      "name": "@repo/typescript-config",
+      "name": "@analog/typescript-config",
       "version": "0.0.1",
     },
   },
@@ -180,6 +180,22 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@analog/api": ["@analog/api@workspace:packages/api"],
+
+    "@analog/auth": ["@analog/auth@workspace:packages/auth"],
+
+    "@analog/db": ["@analog/db@workspace:packages/db"],
+
+    "@analog/env": ["@analog/env@workspace:packages/env"],
+
+    "@analog/eslint-config": ["@analog/eslint-config@workspace:tooling/eslint-config"],
+
+    "@analog/google-calendar": ["@analog/google-calendar@workspace:packages/google-calendar"],
+
+    "@analog/typescript-config": ["@analog/typescript-config@workspace:tooling/typescript-config"],
+
+    "@analog/web": ["@analog/web@workspace:apps/web"],
 
     "@ark/schema": ["@ark/schema@0.46.0", "", { "dependencies": { "@ark/util": "0.46.0" } }, "sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ=="],
 
@@ -481,22 +497,6 @@
 
     "@remixicon/react": ["@remixicon/react@4.6.0", "", { "peerDependencies": { "react": ">=18.2.0" } }, "sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w=="],
 
-    "@repo/api": ["@repo/api@workspace:packages/api"],
-
-    "@repo/auth": ["@repo/auth@workspace:packages/auth"],
-
-    "@repo/db": ["@repo/db@workspace:packages/db"],
-
-    "@repo/env": ["@repo/env@workspace:packages/env"],
-
-    "@repo/eslint-config": ["@repo/eslint-config@workspace:tooling/eslint-config"],
-
-    "@repo/google-calendar": ["@repo/google-calendar@workspace:packages/google-calendar"],
-
-    "@repo/typescript-config": ["@repo/typescript-config@workspace:tooling/typescript-config"],
-
-    "@repo/web": ["@repo/web@workspace:apps/web"],
-
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.11.0", "", {}, "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ=="],
@@ -545,9 +545,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.7", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.7", "@tailwindcss/oxide": "4.1.7", "postcss": "^8.4.41", "tailwindcss": "4.1.7" } }, "sha512-88g3qmNZn7jDgrrcp3ZXEQfp9CVox7xjP1HN2TFKI03CltPVd/c61ydn5qJJL8FYunn0OqBaW5HNUga0kmPVvw=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.76.0", "", {}, "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.77.0", "", {}, "sha512-PFeWjgMQjOsnxBwnW/TJoO0pCja2dzuMQoZ3Diho7dPz7FnTUwTrjNmdf08evrhSE5nvPIKeqV6R0fvQfmhGeg=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.76.1", "", { "dependencies": { "@tanstack/query-core": "5.76.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.77.0", "", { "dependencies": { "@tanstack/query-core": "5.77.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-jX52ot8WxWzWnAknpRSEWj6PTR/7nkULOfoiaVPk6nKu0otwt30UMBC9PTg/m1x0uhz1g71/imwjViTm/oYHxA=="],
 
     "@trpc/client": ["@trpc/client@11.1.2", "", { "peerDependencies": { "@trpc/server": "11.1.2", "typescript": ">=5.7.2" } }, "sha512-RpifJOAv+ql9gF3oafa3dLCF01AzWu2DzejvehAPG2IlwHxopKoYXaImJ8zPwRkZokuWiKz5v65HjElmi8TlrQ=="],
 
@@ -563,9 +563,9 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@20.17.49", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-lu4U+g0EbSW2aPGksNyqcesB2D3eDD0mv8ig9youJsEs/DuMOdeqcEbFOBDCCurXNpa10NkKSSRfOQLBFCiD8w=="],
+    "@types/node": ["@types/node@20.17.50", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A=="],
 
-    "@types/react": ["@types/react@19.1.4", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g=="],
+    "@types/react": ["@types/react@19.1.5", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g=="],
 
     "@types/react-dom": ["@types/react-dom@19.1.5", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg=="],
 
@@ -755,7 +755,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
 
-    "es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
+    "es-abstract": ["es-abstract@1.23.10", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -1083,22 +1083,6 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "pg": ["pg@8.16.0", "", { "dependencies": { "pg-connection-string": "^2.9.0", "pg-pool": "^3.10.0", "pg-protocol": "^1.10.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.2.5" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-7SKfdvP8CTNXjMUzfcVTaI+TDzBEeaUnVwiVGZQD1Hh33Kpev7liQba9uLd4CfN8r9mCVsD0JIpq03+Unpz+kg=="],
-
-    "pg-cloudflare": ["pg-cloudflare@1.2.5", "", {}, "sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg=="],
-
-    "pg-connection-string": ["pg-connection-string@2.9.0", "", {}, "sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ=="],
-
-    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
-
-    "pg-pool": ["pg-pool@3.10.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-DzZ26On4sQ0KmqnO34muPcmKbhrjmyiO4lCCR0VwEd7MjmiKf5NTg/6+apUEu0NF7ESa37CGzFxH513CoUmWnA=="],
-
-    "pg-protocol": ["pg-protocol@1.10.0", "", {}, "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q=="],
-
-    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
-
-    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
-
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -1107,15 +1091,7 @@
 
     "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
-    "postgres": ["postgres@3.4.6", "", {}, "sha512-MXrZVqgUfiirfZ0MqQqXqZQa6oM5OWFjfuaHVKl7v2zW25LnOJeLpQk+UUW0ZuP94fcS+fZVqyDYm9v5SIJ11Q=="],
-
-    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
-
-    "postgres-bytea": ["postgres-bytea@1.0.0", "", {}, "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="],
-
-    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
-
-    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+    "postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1206,8 +1182,6 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
-
-    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
@@ -1313,13 +1287,11 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
-
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.12", "", {}, "sha512-A8e9eiwm2L5YEupdjn1YcxL1ZDWuL3Bc4JKvLwUrpKZZtRUDOijR7XXsV5WMuUCZPc1tFYO5yfH14STI08MquA=="],
+    "zod": ["zod@3.25.28", "", {}, "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/base";
+import { config } from "@analog/eslint-config/base";
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/api",
+  "name": "@analog/api",
   "version": "0.1.0",
   "private": true,
   "exports": {
@@ -18,14 +18,14 @@
     "zod": "^3.24.4"
   },
   "dependencies": {
-    "@repo/auth": "workspace:*",
-    "@repo/db": "workspace:*",
-    "@repo/env": "workspace:*",
-    "@repo/google-calendar": "workspace:*"
+    "@analog/auth": "workspace:*",
+    "@analog/db": "workspace:*",
+    "@analog/env": "workspace:*",
+    "@analog/google-calendar": "workspace:*"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "@analog/eslint-config": "workspace:*",
+    "@analog/typescript-config": "workspace:*",
     "@types/node": "^20",
     "eslint": "^9",
     "typescript": "^5"

--- a/packages/api/src/providers/google-calendar.ts
+++ b/packages/api/src/providers/google-calendar.ts
@@ -1,4 +1,4 @@
-import { GoogleCalendar } from "@repo/google-calendar";
+import { GoogleCalendar } from "@analog/google-calendar";
 
 interface GoogleCalendarProviderOptions {
   accessToken: string;

--- a/packages/api/src/routers/calendars.ts
+++ b/packages/api/src/routers/calendars.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { auth } from "@repo/auth/server";
+import { auth } from "@analog/auth/server";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { GoogleCalendarProvider } from "../providers/google-calendar";
 import { z } from "zod";

--- a/packages/api/src/routers/early-access.ts
+++ b/packages/api/src/routers/early-access.ts
@@ -1,5 +1,5 @@
-import { db } from "@repo/db";
-import { waitlist } from "@repo/db/schema";
+import { db } from "@analog/db";
+import { waitlist } from "@analog/db/schema";
 import { count, eq } from "drizzle-orm";
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "../trpc";

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -2,8 +2,8 @@ import "server-only";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { ZodError } from "zod";
 import superjson from "superjson";
-import { db } from "@repo/db";
-import { auth } from "@repo/auth/server";
+import { db } from "@analog/db";
+import { auth } from "@analog/auth/server";
 
 export const createTRPCContext = async (opts: { headers: Headers }) => {
   const session = await auth.api.getSession({

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/base.json",
+  "extends": "@analog/typescript-config/base.json",
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/packages/auth/eslint.config.mjs
+++ b/packages/auth/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/base";
+import { config } from "@analog/eslint-config/base";
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/auth",
+  "name": "@analog/auth",
   "version": "0.1.0",
   "private": true,
   "exports": {
@@ -14,12 +14,12 @@
     "server-only": "^0.0.1"
   },
   "dependencies": {
-    "@repo/db": "workspace:*",
-    "@repo/env": "workspace:*"
+    "@analog/db": "workspace:*",
+    "@analog/env": "workspace:*"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "@analog/eslint-config": "workspace:*",
+    "@analog/typescript-config": "workspace:*",
     "@types/node": "^20",
     "eslint": "^9",
     "typescript": "^5"

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,8 +1,8 @@
 import "server-only";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { db } from "@repo/db";
-import { env } from "@repo/env/server";
+import { db } from "@analog/db";
+import { env } from "@analog/env/server";
 
 export const GOOGLE_OAUTH_SCOPES = [
   "email",

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/base.json",
+  "extends": "@analog/typescript-config/base.json",
   "compilerOptions": {
     "composite": false,
     "declaration": false,

--- a/packages/db/eslint.config.mjs
+++ b/packages/db/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/base";
+import { config } from "@analog/eslint-config/base";
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/db",
+  "name": "@analog/db",
   "version": "0.1.0",
   "private": true,
   "exports": {
@@ -15,14 +15,14 @@
     "format": "prettier --write \"**/*.{ts,tsx,css,,md}\""
   },
   "dependencies": {
-    "@repo/env": "workspace:*",
+    "@analog/env": "workspace:*",
     "drizzle-orm": "^0.43.1",
     "postgres": "^3.4.5",
     "server-only": "^0.0.1"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "@analog/eslint-config": "workspace:*",
+    "@analog/typescript-config": "workspace:*",
     "@types/node": "^20",
     "drizzle-kit": "^0.31.1",
     "eslint": "^9",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
-import { env } from "@repo/env/server";
+import { env } from "@analog/env/server";
 import * as schema from "./schema";
 
 // Disable prefetch as it is not supported for Supabase "Transaction" pool mode

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/base.json",
+  "extends": "@analog/typescript-config/base.json",
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/packages/env/eslint.config.mjs
+++ b/packages/env/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/base";
+import { config } from "@analog/eslint-config/base";
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/env",
+  "name": "@analog/env",
   "version": "0.1.0",
   "private": true,
   "exports": {
@@ -14,8 +14,8 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "@analog/eslint-config": "workspace:*",
+    "@analog/typescript-config": "workspace:*",
     "@types/node": "^20",
     "eslint": "^9",
     "typescript": "^5"

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/base.json",
+  "extends": "@analog/typescript-config/base.json",
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/packages/google-calendar/package.json
+++ b/packages/google-calendar/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/google-calendar",
+  "name": "@analog/google-calendar",
   "version": "0.0.1-alpha.0",
   "private": true,
   "exports": {
@@ -7,7 +7,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@repo/typescript-config": "workspace:*",
+    "@analog/typescript-config": "workspace:*",
     "@types/node": "^20",
     "typescript": "^5"
   }

--- a/packages/google-calendar/tsconfig.json
+++ b/packages/google-calendar/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/base.json",
+  "extends": "@analog/typescript-config/base.json",
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/tooling/eslint-config/package.json
+++ b/tooling/eslint-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/eslint-config",
+  "name": "@analog/eslint-config",
   "version": "0.0.0",
   "type": "module",
   "private": true,

--- a/tooling/typescript-config/package.json
+++ b/tooling/typescript-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/typescript-config",
+  "name": "@analog/typescript-config",
   "version": "0.0.1",
   "private": true
 }


### PR DESCRIPTION
Replaces the placeholder `@repo/*` scope with `@analog/*` across all packages in the repo, updating import paths, config files, and references. Verified the app builds locally.