### PR TITLE
fix:removed "disabled" on Month and Agenda options of view selector

### DIFF
--- a/apps/web/src/components/event-calendar/calendar-view-selector.tsx
+++ b/apps/web/src/components/event-calendar/calendar-view-selector.tsx
@@ -41,7 +41,7 @@ export function CalendarViewSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-32">
-        <DropdownMenuItem onClick={() => onViewChange("month")} disabled>
+        <DropdownMenuItem onClick={() => onViewChange("month")}>
           Month <DropdownMenuShortcut>M</DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => onViewChange("week")}>
@@ -50,7 +50,7 @@ export function CalendarViewSelector({
         <DropdownMenuItem onClick={() => onViewChange("day")}>
           Day <DropdownMenuShortcut>D</DropdownMenuShortcut>
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => onViewChange("agenda")} disabled>
+        <DropdownMenuItem onClick={() => onViewChange("agenda")}>
           Agenda <DropdownMenuShortcut>A</DropdownMenuShortcut>
         </DropdownMenuItem>
       </DropdownMenuContent>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled selection of "month" and "agenda" options in the calendar view selector dropdown, allowing users to switch to these views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->