### PR TITLE
Fix:use utils for next and prev

### DIFF
--- a/apps/web/src/components/event-calendar/calendar-constants.ts
+++ b/apps/web/src/components/event-calendar/calendar-constants.ts
@@ -3,6 +3,9 @@ export const KEYBOARD_SHORTCUTS = {
   WEEK: "w",
   DAY: "d",
   AGENDA: "a",
+  NEXT_PERIOD: "n",
+  PREVIOUS_PERIOD: "p",
+  TODAY: "t",
 } as const;
 
 export const TIME_INTERVALS = {

--- a/apps/web/src/components/event-calendar/hooks/use-keyboard-shortcuts.ts
+++ b/apps/web/src/components/event-calendar/hooks/use-keyboard-shortcuts.ts
@@ -1,8 +1,13 @@
 import { useEffect } from "react";
-import { shouldIgnoreKeyboardEvent } from "../utils";
+import {
+  navigateToNext,
+  navigateToPrevious,
+  shouldIgnoreKeyboardEvent,
+} from "../utils";
 import { KEYBOARD_SHORTCUTS } from "../calendar-constants";
 import { useCalendarContext } from "@/contexts/calendar-context";
 import { addDays, addMonths, startOfMonth, subDays, subMonths } from "date-fns";
+import { useCalendarNavigation } from "./use-calendar-navigation";
 
 interface UseKeyboardShortcutsProps {
   isEventDialogOpen: boolean;
@@ -11,7 +16,12 @@ interface UseKeyboardShortcutsProps {
 export function useKeyboardShortcuts({
   isEventDialogOpen,
 }: UseKeyboardShortcutsProps) {
-  const { view, setView, setCurrentDate } = useCalendarContext();
+  const { currentDate, view, setView, setCurrentDate } = useCalendarContext();
+  const { handlePrevious, handleNext, handleToday } = useCalendarNavigation({
+    currentDate,
+    setCurrentDate,
+    view,
+  });
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -36,41 +46,10 @@ export function useKeyboardShortcuts({
           setCurrentDate(new Date());
           break;
         case KEYBOARD_SHORTCUTS.NEXT_PERIOD:
-          switch (view) {
-            case "month":
-              setCurrentDate((prevDate) => {
-                return startOfMonth(addMonths(prevDate, 1));
-              });
-              break;
-            case "week":
-              setCurrentDate((prevDate) => addDays(prevDate, 7));
-              break;
-            case "day":
-            case "agenda":
-              setCurrentDate((prevDate) => {
-                return addDays(prevDate, 1);
-              });
-              break;
-          }
-
+          setCurrentDate((prevDate) => navigateToNext(prevDate, view));
           break;
         case KEYBOARD_SHORTCUTS.PREVIOUS_PERIOD:
-          switch (view) {
-            case "month":
-              setCurrentDate((prevDate) => {
-                return startOfMonth(subMonths(prevDate, 1));
-              });
-              break;
-            case "week":
-              setCurrentDate((prevDate) => subDays(prevDate, 7));
-              break;
-            case "day":
-            case "agenda":
-              setCurrentDate((prevDate) => {
-                return subDays(prevDate, 1);
-              });
-              break;
-          }
+          setCurrentDate((prevDate) => navigateToPrevious(prevDate, view));
           break;
       }
     };

--- a/apps/web/src/components/event-calendar/hooks/use-keyboard-shortcuts.ts
+++ b/apps/web/src/components/event-calendar/hooks/use-keyboard-shortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { shouldIgnoreKeyboardEvent } from "../utils";
 import { KEYBOARD_SHORTCUTS } from "../calendar-constants";
 import { useCalendarContext } from "@/contexts/calendar-context";
+import { addDays, addMonths, startOfMonth } from "date-fns";
 
 interface UseKeyboardShortcutsProps {
   isEventDialogOpen: boolean;
@@ -10,7 +11,7 @@ interface UseKeyboardShortcutsProps {
 export function useKeyboardShortcuts({
   isEventDialogOpen,
 }: UseKeyboardShortcutsProps) {
-  const { setView } = useCalendarContext();
+  const { view, setView, setCurrentDate } = useCalendarContext();
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -31,10 +32,35 @@ export function useKeyboardShortcuts({
         case KEYBOARD_SHORTCUTS.AGENDA:
           setView("agenda");
           break;
+        case KEYBOARD_SHORTCUTS.TODAY:
+          setCurrentDate(new Date());
+          break;
+        case KEYBOARD_SHORTCUTS.NEXT_PERIOD:
+          switch (view) {
+            case "month":
+              setCurrentDate((prevDate) => {
+                return startOfMonth(addMonths(prevDate, 1));
+              });
+              break;
+            case "week":
+              setCurrentDate((prevDate) => addDays(prevDate, 7));
+              break;
+            case "day":
+            case "agenda":
+              setCurrentDate((prevDate) => {
+                return addDays(prevDate, 1);
+              });
+              break;
+          }
+
+          break;
+        case KEYBOARD_SHORTCUTS.PREVIOUS_PERIOD:
+          setCurrentDate(new Date());
+          break;
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isEventDialogOpen, setView]);
+  }, [view, isEventDialogOpen]);
 }

--- a/apps/web/src/components/event-calendar/hooks/use-keyboard-shortcuts.ts
+++ b/apps/web/src/components/event-calendar/hooks/use-keyboard-shortcuts.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { shouldIgnoreKeyboardEvent } from "../utils";
 import { KEYBOARD_SHORTCUTS } from "../calendar-constants";
 import { useCalendarContext } from "@/contexts/calendar-context";
-import { addDays, addMonths, startOfMonth } from "date-fns";
+import { addDays, addMonths, startOfMonth, subDays, subMonths } from "date-fns";
 
 interface UseKeyboardShortcutsProps {
   isEventDialogOpen: boolean;
@@ -55,7 +55,22 @@ export function useKeyboardShortcuts({
 
           break;
         case KEYBOARD_SHORTCUTS.PREVIOUS_PERIOD:
-          setCurrentDate(new Date());
+          switch (view) {
+            case "month":
+              setCurrentDate((prevDate) => {
+                return startOfMonth(subMonths(prevDate, 1));
+              });
+              break;
+            case "week":
+              setCurrentDate((prevDate) => subDays(prevDate, 7));
+              break;
+            case "day":
+            case "agenda":
+              setCurrentDate((prevDate) => {
+                return subDays(prevDate, 1);
+              });
+              break;
+          }
           break;
       }
     };

--- a/apps/web/src/contexts/calendar-context.tsx
+++ b/apps/web/src/contexts/calendar-context.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import React, { createContext, useContext, useState } from "react";
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useState,
+} from "react";
 import { CalendarView } from "@/components/event-calendar";
 
 interface CalendarContextType {
   currentDate: Date;
-  setCurrentDate: (date: Date) => void;
+  setCurrentDate: Dispatch<SetStateAction<Date>>;
   view: CalendarView;
   setView: (view: CalendarView) => void;
 }
 
 const CalendarContext = createContext<CalendarContextType | undefined>(
-  undefined,
+  undefined
 );
 
 export function CalendarProvider({
@@ -21,7 +27,7 @@ export function CalendarProvider({
   children: React.ReactNode;
   initialView?: CalendarView;
 }) {
-  const [currentDate, setCurrentDate] = useState(new Date());
+  const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [view, setView] = useState<CalendarView>(initialView);
 
   const value = {
@@ -42,7 +48,7 @@ export function useCalendarContext() {
   const context = useContext(CalendarContext);
   if (context === undefined) {
     throw new Error(
-      "useCalendarContext must be used within a CalendarProvider",
+      "useCalendarContext must be used within a CalendarProvider"
     );
   }
   return context;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts for navigating to the next period ("n"), previous period ("p"), and jumping to today ("t") in the event calendar.

- **Refactor**
  - Improved type annotations and formatting in the calendar context for better consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->