### PR TITLE
feat: add `withGoogleCalendar` tRPC middleware for injecting `GoogleCalendarProvider`

### DIFF
--- a/packages/api/src/routers/calendars.ts
+++ b/packages/api/src/routers/calendars.ts
@@ -1,26 +1,8 @@
-import { TRPCError } from "@trpc/server";
-
-import { auth } from "@repo/auth/server";
-
-import { GoogleCalendarProvider } from "../providers/google-calendar";
-import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { createTRPCRouter, protectedProcedure, withGoogleCalendar } from "../trpc";
 
 export const calendarsRouter = createTRPCRouter({
-  list: protectedProcedure.query(async ({ ctx }) => {
-    const { accessToken } = await auth.api.getAccessToken({
-      body: {
-        providerId: "google",
-      },
-      headers: ctx.headers,
-    });
-
-    if (!accessToken) {
-      throw new TRPCError({ code: "UNAUTHORIZED" });
-    }
-
-    const client = new GoogleCalendarProvider({
-      accessToken,
-    });
+  list: protectedProcedure.use(withGoogleCalendar).query(async ({ ctx }) => {
+    const client = ctx.calendarClient;
 
     const calendars = await client.calendars();
 

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -44,11 +44,12 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
+  const { session, user } = ctx;
+
   return next({
     ctx: {
-      ...ctx,
-      session: { ...ctx.session },
-      user: { ...ctx.user },
+      session,
+      user,
     },
   });
 });


### PR DESCRIPTION
This PR introduces a new tRPC middleware, `withGoogleCalendar`, which centralizes the logic for fetching the user’s Google OAuth access token and instantiating a `GoogleCalendarProvider`. By attaching the calendar client to the tRPC context (`ctx.calendarClient`), downstream procedures can simply call `ctx.ctx.calendarClient.*` without repeating boilerplate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**  
  - Centralized Google Calendar client setup via middleware across calendar and event features, enhancing performance and reliability without changing user experience.  
- **Chores**  
  - Improved internal authentication and context management for smoother integration with Google Calendar services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->