### PR TITLE
fix: use utils for next and previous to react-hotkeys-hook implementation

### DIFF
--- a/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
+++ b/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import { addDays, addMonths, startOfMonth, subDays, subMonths } from "date-fns";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { useCalendarContext } from "@/contexts/calendar-context";
+import { navigateToNext, navigateToPrevious } from "@/components/event-calendar";
 
 export const KEYBOARD_SHORTCUTS = {
   MONTH: "m",
@@ -36,39 +36,13 @@ export function CalendarHotkeys() {
 
   useHotkeys(
     KEYBOARD_SHORTCUTS.NEXT_PERIOD,
-    () => {
-      switch (view) {
-        case "month":
-          setCurrentDate((prevDate) => startOfMonth(addMonths(prevDate, 1)));
-          break;
-        case "week":
-          setCurrentDate((prevDate) => addDays(prevDate, 7));
-          break;
-        case "day":
-        case "agenda":
-          setCurrentDate((prevDate) => addDays(prevDate, 1));
-          break;
-      }
-    },
+    () => setCurrentDate((prevDate) => navigateToNext(prevDate, view)),
     { scopes: ["calendar"] },
   );
 
   useHotkeys(
     KEYBOARD_SHORTCUTS.PREVIOUS_PERIOD,
-    () => {
-      switch (view) {
-        case "month":
-          setCurrentDate((prevDate) => startOfMonth(subMonths(prevDate, 1)));
-          break;
-        case "week":
-          setCurrentDate((prevDate) => subDays(prevDate, 7));
-          break;
-        case "day":
-        case "agenda":
-          setCurrentDate((prevDate) => subDays(prevDate, 1));
-          break;
-      }
-    },
+    () => setCurrentDate((prevDate) => navigateToPrevious(prevDate, view)),
     { scopes: ["calendar"] },
   );
 


### PR DESCRIPTION
Applying changes from #68 to the new `react-hotkeys-hook` implementation.