### PR TITLE
feat: group calendars [Not merge]

### DIFF
--- a/apps/web/src/components/calendars.tsx
+++ b/apps/web/src/components/calendars.tsx
@@ -29,6 +29,7 @@ export type CalendarItem = {
   provider: string;
   name: string;
   primary: boolean | undefined;
+  isOwner: boolean;
 };
 
 function useCalendarList() {
@@ -50,28 +51,64 @@ export function Calendars() {
 
   return (
     <div className="relative flex scrollbar-hidden flex-1 flex-col gap-2 overflow-auto">
-      {data.accounts.map((account, index) => (
-        <Fragment key={account.name}>
-          <SidebarGroup key={account.name} className="py-0">
-            <Collapsible
-              defaultOpen={index === 0}
-              className="group/collapsible"
-            >
-              <CalendarName name={account.name} />
-              <CollapsibleContent>
-                <SidebarGroupContent>
-                  <SidebarMenu>
-                    {account.calendars.map((item: CalendarItem) => (
-                      <ItemWithToggle key={item.id} item={item} />
-                    ))}
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </CollapsibleContent>
-            </Collapsible>
-          </SidebarGroup>
-          <SidebarSeparator className="mx-0" />
-        </Fragment>
-      ))}
+      {data.accounts.map((account, index) => {
+        // Split calendars into owned and not owned
+        const myCalendars = account.calendars.filter((item: CalendarItem) => item.isOwner);
+        const otherCalendars = account.calendars.filter((item: CalendarItem) => !item.isOwner);
+        
+        return (
+          <Fragment key={account.name}>
+            <SidebarGroup key={account.name} className="py-0">
+              <Collapsible
+                defaultOpen={index === 0}
+                className="group/collapsible"
+              >
+                <CalendarName name={account.name} />
+                <CollapsibleContent>
+                  <SidebarGroupContent>
+                    {myCalendars.length > 0 && (
+                      <Collapsible defaultOpen={true} className="group/my-calendars">
+                        <SidebarGroupLabel asChild className="text-sm hover:bg-sidebar-accent">
+                          <CollapsibleTrigger className="flex w-full items-center justify-between px-2 py-1">
+                            <span>My calendars</span>
+                            <ChevronRight className="transition-transform group-data-[state=open]/my-calendars:rotate-90" />
+                          </CollapsibleTrigger>
+                        </SidebarGroupLabel>
+                        <CollapsibleContent>
+                          <SidebarMenu>
+                            {myCalendars.map((item: CalendarItem) => (
+                              <ItemWithToggle key={item.id} item={item} />
+                            ))}
+                          </SidebarMenu>
+                        </CollapsibleContent>
+                      </Collapsible>
+                    )}
+                    
+                    {otherCalendars.length > 0 && (
+                      <Collapsible defaultOpen={true} className="group/other-calendars">
+                        <SidebarGroupLabel asChild className="text-sm hover:bg-sidebar-accent">
+                          <CollapsibleTrigger className="flex w-full items-center justify-between px-2 py-1">
+                            <span>Other calendars</span>
+                            <ChevronRight className="transition-transform group-data-[state=open]/other-calendars:rotate-90" />
+                          </CollapsibleTrigger>
+                        </SidebarGroupLabel>
+                        <CollapsibleContent>
+                          <SidebarMenu>
+                            {otherCalendars.map((item: CalendarItem) => (
+                              <ItemWithToggle key={item.id} item={item} />
+                            ))}
+                          </SidebarMenu>
+                        </CollapsibleContent>
+                      </Collapsible>
+                    )}
+                  </SidebarGroupContent>
+                </CollapsibleContent>
+              </Collapsible>
+            </SidebarGroup>
+            <SidebarSeparator className="mx-0" />
+          </Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/packages/api/src/constants/calendar.ts
+++ b/packages/api/src/constants/calendar.ts
@@ -22,3 +22,8 @@ export const colorMap = {
 
 export type EventColorId = keyof typeof colorMap;
 export type EventColor = (typeof colorMap)[EventColorId];
+
+export const GOOGLE_CALENDAR_PROVIDER_CONSTANTS = {
+  owner: "owner",
+} as const;
+

--- a/packages/api/src/providers/google-calendar.ts
+++ b/packages/api/src/providers/google-calendar.ts
@@ -1,11 +1,12 @@
 import { GoogleCalendar } from "@repo/google-calendar";
 
-import { CALENDAR_DEFAULTS } from "../constants/calendar";
+import { CALENDAR_DEFAULTS, GOOGLE_CALENDAR_PROVIDER_CONSTANTS } from "../constants/calendar";
 import { dateHelpers } from "../utils/date-helpers";
 import type { CalendarEvent, CalendarProvider } from "./types";
 
 interface GoogleCalendarProviderOptions {
   accessToken: string;
+  email: string;
 }
 
 // Type definitions for Google Calendar API
@@ -52,6 +53,7 @@ export class GoogleCalendarProvider implements CalendarProvider {
         provider: "google",
         name: calendar.summary!,
         primary: calendar.primary || false,
+        isOwner: calendar.accessRole === GOOGLE_CALENDAR_PROVIDER_CONSTANTS.owner,
       }));
   }
 

--- a/packages/api/src/providers/index.ts
+++ b/packages/api/src/providers/index.ts
@@ -22,5 +22,5 @@ export function accountToProvider(
     throw new Error("Provider not supported");
   }
 
-  return new Provider({ accessToken: activeAccount.accessToken });
+  return new Provider({ accessToken: activeAccount.accessToken, email: activeAccount.email });
 }

--- a/packages/api/src/providers/types.ts
+++ b/packages/api/src/providers/types.ts
@@ -8,6 +8,7 @@ export interface Calendar {
   provider: string;
   name: string;
   primary: boolean;
+  isOwner: boolean;
 }
 
 export interface CalendarEvent {


### PR DESCRIPTION
# Changes

Now we get the calendars grouped 

![Screenshot 2025-06-03 at 12 01 32 p m](https://github.com/user-attachments/assets/72a8d914-637c-4bc3-9a8f-1b5f47157fd0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendars are now grouped into "My calendars" and "Other calendars" within each account, allowing for clearer distinction between owned and non-owned calendars.
  - Each group is displayed in its own collapsible section for improved navigation and organization.

- **Enhancements**
  - Calendar lists now indicate ownership status, providing more context for each calendar.
  - Improved integration with Google and Microsoft calendar providers to accurately reflect calendar ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->