### PR TITLE
Fix token retrieval for fallback active account

### DIFF
--- a/packages/api/src/utils/accounts.ts
+++ b/packages/api/src/utils/accounts.ts
@@ -40,7 +40,19 @@ export const getActiveAccount = async (
     throw new Error("No account found");
   }
 
-  return firstAccount;
+  const { accessToken } = await auth.api.getAccessToken({
+    body: {
+      providerId: firstAccount.providerId,
+      accountId: firstAccount.id,
+      userId: firstAccount.userId,
+    },
+    headers,
+  });
+
+  return {
+    ...firstAccount,
+    accessToken: accessToken ?? firstAccount.accessToken,
+  };
 };
 
 export const getAllAccounts = async (


### PR DESCRIPTION
## Summary
- refresh access token when falling back to first account

## Testing
- `npx tsc -p packages/api/tsconfig.json` *(fails: Cannot find global value 'Promise', missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840cdc7133c832bb7db7551f28c4d8c