### PR TITLE
Add calendar-aware year comparison

### DIFF
--- a/packages/api/src/utils/temporal.ts
+++ b/packages/api/src/utils/temporal.ts
@@ -86,9 +86,11 @@ export interface IsSameYearOptions {
 }
 
 export function isSameYear({ a, b, timeZone }: IsSameYearOptions) {
-  // TODO: Handle different calendar systems
-  return (
-    toPlainYearMonth({ value: a, timeZone }).year ===
-    toPlainYearMonth({ value: b, timeZone }).year
-  );
+  const yearA = toPlainDate({ value: a, timeZone })
+    .withCalendar("iso8601")
+    .year;
+  const yearB = toPlainDate({ value: b, timeZone })
+    .withCalendar("iso8601")
+    .year;
+  return yearA === yearB;
 }


### PR DESCRIPTION
## Summary
- support non-ISO calendars in `isSameYear`

## Testing
- `bun run lint`
- `bun test` *(fails: "The following filters did not match any test files")*

------
https://chatgpt.com/codex/tasks/task_e_684f620ea8f4832bb86e3c601f829b63