### PR TITLE
Fix Temporal.Instant handling for Microsoft calendar

### DIFF
--- a/packages/api/src/providers/microsoft-calendar/utils.ts
+++ b/packages/api/src/providers/microsoft-calendar/utils.ts
@@ -18,8 +18,18 @@ export function toMicrosoftDate(
   }
 
   if (value instanceof Temporal.Instant) {
-    // TODO: might cause issues copying events from other providers
-    throw new Error("Temporal.Instant is not supported");
+    // Microsoft Graph expects dateTime without a zone but formatted using UTC.
+    // Convert the instant to UTC first and output with seven fractional digits
+    // to match the required `{date}T{time}` format.
+    const dateTime = value
+      .toZonedDateTimeISO("UTC")
+      .toPlainDateTime()
+      .toString({ fractionalSecondDigits: 7 });
+
+    return {
+      dateTime,
+      timeZone: "UTC",
+    };
   }
 
   return {


### PR DESCRIPTION
## Summary
- handle Temporal.Instant in Microsoft calendar utils by converting to UTC and formatting with 7 fractional digits

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684f62118030832b9f09fecebfd319ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved date handling to support `Temporal.Instant` values, ensuring compatibility with Microsoft Graph date-time formatting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->