### PR TITLE
Remove the Simple Analytics error on start up

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from "next";
 import withSimpleAnalytics from "@simpleanalytics/next/plugin";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_SIMPLE_ANALYTICS_HOSTNAME:
+      process.env.NEXT_PUBLIC_SIMPLE_ANALYTICS_HOSTNAME ?? "localhost",
+  },
 };
 
 export default withSimpleAnalytics(nextConfig);


### PR DESCRIPTION
## Description

simpleanalytics package is dumb cause they throw a console error for the missing hostname _before_ checking if we're running in a dev environment

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup
