### PR TITLE
Implement account sign-in enable/disable

### DIFF
--- a/packages/db/drizzle/0004_sign_in_enabled.sql
+++ b/packages/db/drizzle/0004_sign_in_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "account" ADD COLUMN "sign_in_enabled" boolean DEFAULT false NOT NULL;

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -42,6 +42,9 @@ export const account = pgTable("account", {
   accessTokenExpiresAt: timestamp(),
   refreshTokenExpiresAt: timestamp(),
   scope: text(),
+  signInEnabled: boolean()
+    .$defaultFn(() => false)
+    .notNull(),
   password: text(),
   createdAt: timestamp().notNull(),
   updatedAt: timestamp().notNull(),


### PR DESCRIPTION
## Summary
- add `signInEnabled` flag for accounts with migration
- automatically set sign-in for the first account
- expose sign-in status via API
- allow enabling/disabling sign-in and prevent removing last sign-in-capable account

## Testing
- `bun run format`
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851bcbaae60832bb929b8ede23e53a0