### PR TITLE
Implemented Track Waitlist Join Status Using localStorage #82

### DIFF
--- a/apps/web/src/atoms/index.ts
+++ b/apps/web/src/atoms/index.ts
@@ -1,5 +1,5 @@
 export { viewPreferencesAtom, type ViewPreferences } from "./view-preferences";
-
+export { waitlistJoinedAtom } from "./waitlist-persistence";
 export {
   calendarsVisibilityAtom,
   type CalendarsVisibility,

--- a/apps/web/src/atoms/waitlist-persistence.ts
+++ b/apps/web/src/atoms/waitlist-persistence.ts
@@ -1,0 +1,6 @@
+import { atomWithStorage } from "jotai/utils";
+
+export const waitlistJoinedAtom = atomWithStorage<boolean>(
+  "analog-waitlist-joined",
+  false
+);

--- a/apps/web/src/components/sections/home/waitlist-form.tsx
+++ b/apps/web/src/components/sections/home/waitlist-form.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useTRPC } from "@/lib/trpc/client";
 import { cn } from "@/lib/utils";
+import { useWaitlistPersistence } from "@/hooks/use-waitlist-persistence";
 
 const formSchema = z.object({
   email: z.string().email(),
@@ -27,13 +28,15 @@ function useWaitlistCount() {
 
   const query = useQuery(trpc.earlyAccess.getWaitlistCount.queryOptions());
 
+  const { markAsJoined } = useWaitlistPersistence();
+
   const [success, setSuccess] = useState(false);
 
   const { mutate } = useMutation(
     trpc.earlyAccess.joinWaitlist.mutationOptions({
       onSuccess: () => {
         setSuccess(true);
-
+        markAsJoined()
         queryClient.setQueryData(
           [trpc.earlyAccess.getWaitlistCount.queryKey()],
           {
@@ -63,6 +66,7 @@ export function WaitlistForm({ className }: WaitlistFormProps) {
   });
 
   const waitlist = useWaitlistCount();
+  const { hasJoined } = useWaitlistPersistence();
 
   function joinWaitlist({ email }: FormSchema) {
     waitlist.mutate({ email });
@@ -75,7 +79,7 @@ export function WaitlistForm({ className }: WaitlistFormProps) {
         className,
       )}
     >
-      {waitlist.success ? (
+      {(waitlist.success || hasJoined)  ? (
         <div className="flex flex-col items-center justify-center gap-4 text-center">
           <p className="text-xl font-semibold">
             You&apos;re on the waitlist! 🎉

--- a/apps/web/src/hooks/use-waitlist-persistence.ts
+++ b/apps/web/src/hooks/use-waitlist-persistence.ts
@@ -1,0 +1,12 @@
+import { useAtom } from "jotai";
+import { waitlistJoinedAtom } from "@/atoms/waitlist-persistence";
+
+export function useWaitlistPersistence() {
+  const [hasJoined, setHasJoined] = useAtom(waitlistJoinedAtom);
+
+  const markAsJoined = () => {
+    setHasJoined(true);
+  };
+
+  return { hasJoined, markAsJoined };
+}


### PR DESCRIPTION
## Description

I'd implemented a small UX improvement where we track if a user has already joined the waitlist using localStorage. This way, when users revisit the site, we can inform them that they've already joined—avoiding confusion or duplicate submissions.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [X] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [X] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [X] I’ve read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My code works and is understandable and follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in complex areas
- [X] I have updated the documentation
- [X] Any dependent changes are merged and published

## Demo

https://github.com/user-attachments/assets/beb58fda-c2d5-49f6-a879-5216c544ecc9




_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._
