### PR TITLE
Add calendar RSVP APIs

### DIFF
--- a/packages/api/src/providers/google-calendar.ts
+++ b/packages/api/src/providers/google-calendar.ts
@@ -155,6 +155,60 @@ export class GoogleCalendarProvider implements CalendarProvider {
     });
   }
 
+  async acceptEvent(calendarId: string, eventId: string): Promise<void> {
+    return this.withErrorHandler("acceptEvent", async () => {
+      const event = await this.client.calendars.events.retrieve(eventId, {
+        calendarId,
+      });
+
+      const attendees = event.attendees ?? [];
+      const selfIndex = attendees.findIndex((a) => a.self);
+
+      if (selfIndex >= 0) {
+        attendees[selfIndex] = {
+          ...attendees[selfIndex],
+          responseStatus: "accepted",
+        };
+      } else {
+        attendees.push({ self: true, responseStatus: "accepted" });
+      }
+
+      await this.client.calendars.events.update(eventId, {
+        ...event,
+        calendarId,
+        attendees,
+        sendUpdates: "all",
+      });
+    });
+  }
+
+  async declineEvent(calendarId: string, eventId: string): Promise<void> {
+    return this.withErrorHandler("declineEvent", async () => {
+      const event = await this.client.calendars.events.retrieve(eventId, {
+        calendarId,
+      });
+
+      const attendees = event.attendees ?? [];
+      const selfIndex = attendees.findIndex((a) => a.self);
+
+      if (selfIndex >= 0) {
+        attendees[selfIndex] = {
+          ...attendees[selfIndex],
+          responseStatus: "declined",
+        };
+      } else {
+        attendees.push({ self: true, responseStatus: "declined" });
+      }
+
+      await this.client.calendars.events.update(eventId, {
+        ...event,
+        calendarId,
+        attendees,
+        sendUpdates: "all",
+      });
+    });
+  }
+
   private async withErrorHandler<T>(
     operation: string,
     fn: () => Promise<T> | T,

--- a/packages/api/src/providers/interfaces.ts
+++ b/packages/api/src/providers/interfaces.ts
@@ -60,4 +60,6 @@ export interface CalendarProvider {
     event: UpdateEventInput,
   ): Promise<CalendarEvent>;
   deleteEvent(calendarId: string, eventId: string): Promise<void>;
+  acceptEvent(calendarId: string, eventId: string): Promise<void>;
+  declineEvent(calendarId: string, eventId: string): Promise<void>;
 }

--- a/packages/api/src/providers/microsoft-calendar.ts
+++ b/packages/api/src/providers/microsoft-calendar.ts
@@ -151,6 +151,22 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
     });
   }
 
+  async acceptEvent(calendarId: string, eventId: string): Promise<void> {
+    await this.withErrorHandler("acceptEvent", async () => {
+      await this.graphClient
+        .api(`/me/events/${eventId}/accept`)
+        .post({ comment: "", sendResponse: true });
+    });
+  }
+
+  async declineEvent(calendarId: string, eventId: string): Promise<void> {
+    await this.withErrorHandler("declineEvent", async () => {
+      await this.graphClient
+        .api(`/me/events/${eventId}/decline`)
+        .post({ comment: "", sendResponse: true });
+    });
+  }
+
   private async withErrorHandler<T>(
     operation: string,
     fn: () => Promise<T> | T,

--- a/packages/api/src/routers/events.ts
+++ b/packages/api/src/routers/events.ts
@@ -128,4 +128,52 @@ export const eventsRouter = createTRPCRouter({
 
       return { success: true };
     }),
+  accept: calendarProcedure
+    .input(
+      z.object({
+        accountId: z.string(),
+        calendarId: z.string(),
+        eventId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const provider = ctx.providers.find(
+        ({ account }) => account.id === input.accountId,
+      );
+
+      if (!provider?.client) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Calendar client not found for accountId: ${input.accountId}`,
+        });
+      }
+
+      await provider.client.acceptEvent(input.calendarId, input.eventId);
+
+      return { success: true };
+    }),
+  decline: calendarProcedure
+    .input(
+      z.object({
+        accountId: z.string(),
+        calendarId: z.string(),
+        eventId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const provider = ctx.providers.find(
+        ({ account }) => account.id === input.accountId,
+      );
+
+      if (!provider?.client) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Calendar client not found for accountId: ${input.accountId}`,
+        });
+      }
+
+      await provider.client.declineEvent(input.calendarId, input.eventId);
+
+      return { success: true };
+    }),
 });


### PR DESCRIPTION
## Summary
- extend `CalendarProvider` interface for accepting or declining events
- support RSVP for Google Calendar without overwriting other attendees
- support RSVP for Microsoft Graph
- expose `accept` and `decline` mutations on the events router

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851599764bc832ba1e1170322bed12e