### PR TITLE
Add reminder parsing across calendar providers

### DIFF
--- a/packages/api/src/providers/interfaces.ts
+++ b/packages/api/src/providers/interfaces.ts
@@ -29,9 +29,20 @@ export interface CalendarEvent {
   status?: string;
   url?: string;
   color?: string;
+  reminders?: Reminders;
   providerId: string;
   accountId: string;
   calendarId: string;
+}
+
+export interface Reminder {
+  method?: string;
+  duration: Temporal.Duration;
+}
+
+export interface Reminders {
+  useDefault?: boolean;
+  overrides?: Reminder[];
 }
 
 export interface CalendarProvider {

--- a/packages/api/src/schemas/events.ts
+++ b/packages/api/src/schemas/events.ts
@@ -1,4 +1,5 @@
 import {
+  zDurationInstance,
   zInstantInstance,
   zPlainDateInstance,
   zZonedDateTimeInstance,
@@ -19,6 +20,19 @@ export const createEventInputSchema = z.object({
   description: z.string().optional(),
   location: z.string().optional(),
   color: z.string().optional(),
+  reminders: z
+    .object({
+      useDefault: z.boolean().optional(),
+      overrides: z
+        .array(
+          z.object({
+            method: z.string().optional(),
+            duration: zDurationInstance,
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
   accountId: z.string(),
   calendarId: z.string(),
 });


### PR DESCRIPTION
## Summary
- expand event interface with reminders
- support reminders in create/update event schema
- parse Google Calendar reminders
- parse Microsoft calendar reminders
- use `Temporal.Duration` for reminders instead of raw minutes

## Testing
- `bun run format`
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68514d86459c832ba8549938f0627b93