### PR TITLE
Add reauth flow for missing tokens

### DIFF
--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 
+import { ReauthDialogProvider } from "@/components/reauth-dialog";
 import { ThemeProvider } from "@/components/ui/theme-provider";
 import { TRPCReactProvider } from "@/lib/trpc/client";
 
@@ -13,7 +14,9 @@ export function Providers(props: Readonly<{ children: ReactNode }>) {
       enableSystem
       disableTransitionOnChange
     >
-      <TRPCReactProvider>{props.children}</TRPCReactProvider>
+      <TRPCReactProvider>
+        <ReauthDialogProvider>{props.children}</ReauthDialogProvider>
+      </TRPCReactProvider>
     </ThemeProvider>
   );
 }

--- a/apps/web/src/components/reauth-dialog.tsx
+++ b/apps/web/src/components/reauth-dialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import * as React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { TRPCClientError } from "@trpc/client";
+
+import { authClient } from "@repo/auth/client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function ReauthDialogProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const queryClient = useQueryClient();
+  const [providerId, setProviderId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const unsubscribeQuery = queryClient.getQueryCache().subscribe((event) => {
+      const error = (event as any).query?.state?.error;
+      if (
+        error instanceof TRPCClientError &&
+        typeof error.message === "string" &&
+        error.message.startsWith("REAUTH:")
+      ) {
+        setProviderId(error.message.split(":")[1] ?? null);
+      }
+    });
+
+    const unsubscribeMutation = queryClient
+      .getMutationCache()
+      .subscribe((event) => {
+        const error = (event as any).state?.error;
+        if (
+          error instanceof TRPCClientError &&
+          typeof error.message === "string" &&
+          error.message.startsWith("REAUTH:")
+        ) {
+          setProviderId(error.message.split(":")[1] ?? null);
+        }
+      });
+
+    return () => {
+      unsubscribeQuery();
+      unsubscribeMutation();
+    };
+  }, [queryClient]);
+
+  const close = () => setProviderId(null);
+
+  const handleReauth = async () => {
+    if (!providerId) return;
+    await authClient.linkSocial({
+      provider: providerId as "google" | "microsoft",
+      callbackURL: window.location.href,
+    });
+  };
+
+  return (
+    <>
+      {children}
+      <Dialog
+        open={providerId !== null}
+        onOpenChange={(open) => !open && close()}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Reconnect Account</DialogTitle>
+            <DialogDescription>
+              Please reauthenticate your {providerId ?? ""} account to continue.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end">
+            <Button onClick={handleReauth}>Reconnect</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/api/src/utils/accounts.ts
+++ b/packages/api/src/utils/accounts.ts
@@ -12,9 +12,13 @@ async function withAccessToken(account: Account, headers: Headers) {
     headers,
   });
 
+  if (!accessToken) {
+    throw new Error(`REAUTH:${account.providerId}`);
+  }
+
   return {
     ...account,
-    accessToken: accessToken ?? account.accessToken,
+    accessToken,
   };
 }
 


### PR DESCRIPTION
## Summary
- detect missing access tokens on the server and signal reauth
- show a shadcn dialog prompting the user to reconnect
- wrap app providers with ReauthDialogProvider

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863dfae3500832b9d8e83cb5abcb757