### PR TITLE
feat(web): add support to display week numbers

### DIFF
--- a/apps/web/src/components/calendar-view.tsx
+++ b/apps/web/src/components/calendar-view.tsx
@@ -174,7 +174,7 @@ export function CalendarView({
         } as React.CSSProperties
       }
     >
-      <CalendarHeader ref={headerRef} />
+      <CalendarHeader ref={headerRef} viewPreferences={viewPreferences} />
 
       <div
         className="scrollbar-hidden grow overflow-x-hidden overflow-y-auto"

--- a/apps/web/src/components/event-calendar/calendar-header.tsx
+++ b/apps/web/src/components/event-calendar/calendar-header.tsx
@@ -2,6 +2,7 @@
 
 import { usePrevious } from "@react-hookz/web";
 
+import type { ViewPreferences } from "@/atoms/view-preferences";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useCalendarState } from "@/hooks/use-calendar-state";
 import { cn } from "@/lib/utils";
@@ -10,9 +11,15 @@ import { CalendarNavigation } from "./calendar-navigation";
 import { CalendarViewMenu } from "./calendar-view-menu";
 import { CalendarViewTitle } from "./calendar-view-title";
 
-type CalendarHeaderProps = React.ComponentProps<"header">;
+type CalendarHeaderProps = React.ComponentProps<"header"> & {
+  viewPreferences: ViewPreferences;
+};
 
-export function CalendarHeader({ className, ref }: CalendarHeaderProps) {
+export function CalendarHeader({
+  className,
+  ref,
+  viewPreferences,
+}: CalendarHeaderProps) {
   const { currentDate, view, setView } = useCalendarState();
   const prevDate = usePrevious(currentDate);
 
@@ -31,6 +38,7 @@ export function CalendarHeader({ className, ref }: CalendarHeaderProps) {
           currentDate={currentDate}
           view={view}
           className="text-sm font-medium sm:text-lg md:text-xl"
+          viewPreferences={viewPreferences}
         />
       </div>
 

--- a/apps/web/src/components/event-calendar/calendar-view-title.tsx
+++ b/apps/web/src/components/event-calendar/calendar-view-title.tsx
@@ -2,9 +2,10 @@
 
 import { AnimatePresence, Variant, motion } from "motion/react";
 
+import type { ViewPreferences } from "@/atoms/view-preferences";
 import { cn } from "@/lib/utils";
 import { CalendarView } from "./types";
-import { getViewTitleData } from "./utils";
+import { getViewTitleData, getWeekNumber } from "./utils";
 
 const variants: Record<string, Variant> = {
   exit: {
@@ -31,6 +32,7 @@ interface CalendarViewTitleProps {
   view: CalendarView;
   className?: string;
   prevDate?: Date;
+  viewPreferences: ViewPreferences;
 }
 
 /**
@@ -38,27 +40,9 @@ interface CalendarViewTitleProps {
  */
 
 export function CalendarViewTitle(props: CalendarViewTitleProps) {
-  const { currentDate, view, className } = props;
+  const { currentDate, view, className, viewPreferences } = props;
   const titleData = getViewTitleData(currentDate, view);
-
-  if (view === "day") {
-    return (
-      <motion.h2
-        className={className}
-        key={titleData.full}
-        variants={variants}
-        transition={{ duration: 0.25, ease: "easeInOut" }}
-      >
-        <span className="min-[480px]:hidden" aria-hidden="true">
-          {titleData.short}
-        </span>
-        <span className="max-[479px]:hidden min-md:hidden" aria-hidden="true">
-          {titleData.medium}
-        </span>
-        <span className="max-md:hidden">{titleData.full}</span>
-      </motion.h2>
-    );
-  }
+  const weekNumber = getWeekNumber(currentDate, view);
 
   return (
     <div className="relative h-8 w-full">
@@ -66,7 +50,7 @@ export function CalendarViewTitle(props: CalendarViewTitleProps) {
         <motion.h2
           key={titleData.full}
           className={cn(
-            "absolute inset-0 flex items-center justify-start transition-all",
+            "absolute inset-0 flex items-center justify-start gap-2 transition-all",
             className,
           )}
           variants={variants}
@@ -78,6 +62,11 @@ export function CalendarViewTitle(props: CalendarViewTitleProps) {
             {titleData.short}
           </span>
           <span className="max-md:hidden">{titleData.full}</span>
+          {viewPreferences.showWeekNumbers && weekNumber && (
+            <span className="mt-1 text-sm text-muted-foreground">
+              Week {weekNumber}
+            </span>
+          )}
         </motion.h2>
       </AnimatePresence>
     </div>

--- a/apps/web/src/components/event-calendar/utils/date-time.ts
+++ b/apps/web/src/components/event-calendar/utils/date-time.ts
@@ -21,6 +21,7 @@ import {
   subMonths,
   subWeeks,
 } from "date-fns";
+import { Temporal } from "temporal-polyfill";
 
 import {
   AgendaDaysToShow,
@@ -160,6 +161,17 @@ export function getViewTitleData(currentDate: Date, view: CalendarView) {
     default:
       return getMonthTitle(currentDate);
   }
+}
+
+export function getWeekNumber(
+  currentDate: Date,
+  view: CalendarView,
+): number | undefined {
+  if (view === "month") {
+    return undefined;
+  }
+
+  return Temporal.PlainDate.from(format(currentDate, "yyyy-MM-dd")).weekOfYear;
 }
 
 export function isWeekend(date: Date): boolean {


### PR DESCRIPTION
## Description

Used the Temporal API to display the current week index (ig) next to the current date.

## Screenshots / Recordings

https://github.com/user-attachments/assets/c3106264-2244-4a9d-8964-3c2a3ce5556b

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [x] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Checklist

- [x] I’ve read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My code works and is understandable and follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] Any dependent changes are merged and published
