### PR TITLE
Upgrade Zod to v4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -130,7 +130,7 @@
         "superjson": "^2.2.2",
         "superjson-temporal": "^0.3.1",
         "temporal-zod": "^0.3.1",
-        "zod": "^3.25.76",
+        "zod": "^4.0.2",
       },
     },
     "packages/auth": {
@@ -187,7 +187,7 @@
         "typescript": "^5.8.3",
       },
       "peerDependencies": {
-        "zod": "^3.25.76",
+        "zod": "^4.0.2",
       },
     },
     "packages/google-calendar": {
@@ -2093,7 +2093,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.67", "", {}, "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="],
+    "zod": ["zod@4.0.2", "", {}, "sha512-X2niJNY54MGam4L6Kj0AxeedeDIi/E5QFW0On2faSX5J4/pfLk1tW+cRMIMoojnCavn/u5W/kX17e1CSGnKMxA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "superjson": "^2.2.2",
     "superjson-temporal": "^0.3.1",
     "temporal-zod": "^0.3.1",
-    "zod": "^3.25.76"
+    "zod": "^4.0.2"
   },
   "dependencies": {
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/packages/api/src/providers/colors.ts
+++ b/packages/api/src/providers/colors.ts
@@ -1,10 +1,10 @@
-import z from "zod";
+import { z } from "zod";
 
 const HEX_REGEX = /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
 
 const hexToRgbObjectSchema = z
   .string()
-  .regex(HEX_REGEX, { message: "Invalid hex color format" })
+  .regex(HEX_REGEX, { error: "Invalid hex color format" })
   .transform((rawHex) => {
     let hex = rawHex.replace(/^#/, "");
     if (hex.length === 3) {

--- a/packages/api/src/schemas/events.ts
+++ b/packages/api/src/schemas/events.ts
@@ -14,7 +14,7 @@ const conferenceSchema = z.object({
   password: z.string().optional(),
   phoneNumbers: z.array(z.string()).optional(),
   notes: z.string().optional(),
-  extra: z.record(z.unknown()).optional(),
+  extra: z.record(z.string(), z.unknown()).optional(),
 });
 
 const microsoftMetadataSchema = z.object({

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { TRPCError, initTRPC } from "@trpc/server";
-import { ZodError } from "zod";
+import { ZodError, z } from "zod";
 
 import { auth } from "@repo/auth/server";
 import { db } from "@repo/db";
@@ -30,7 +30,7 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
       data: {
         ...shape.data,
         zodError:
-          error.cause instanceof ZodError ? error.cause.flatten() : null,
+          error.cause instanceof ZodError ? z.flattenError(error.cause) : null,
       },
     };
   },

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "zod": "^3.25.76"
+    "zod": "^4.0.2"
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.13.8"


### PR DESCRIPTION
## Summary
- update zod peer deps to v4.0.2
- regenerate lockfile
- replace deprecated `ZodError.flatten` usage with `z.flattenError`
- fix `z.record` usage in event schema
- update hex color schema to use `error` option

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_686feb89005c832baf9ab2dd4bca8761