### PR TITLE
feat(web): add event-related keyboard shortcuts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@hookform/resolvers": "^5.1.1",
     "@internationalized/date": "^3.8.2",
     "@number-flow/react": "^0.5.10",
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.11",

--- a/apps/web/src/components/calendar-layout.tsx
+++ b/apps/web/src/components/calendar-layout.tsx
@@ -13,6 +13,7 @@ import { CalendarView } from "@/components/calendar-view";
 import { EventForm } from "@/components/event-form/event-form";
 import { RightSidebar } from "@/components/right-sidebar";
 import { SidebarInset } from "@/components/ui/sidebar";
+import { EventHotkeys } from "@/lib/hotkeys/event-hotkeys";
 import { useTRPC } from "@/lib/trpc/client";
 import { useOptimisticEvents } from "./event-calendar/hooks/use-optimistic-events";
 
@@ -43,6 +44,10 @@ function IsolatedCalendarLayout() {
 
   return (
     <>
+      <EventHotkeys
+        selectedEvent={selectedEvents[0]}
+        dispatchAction={dispatchAction}
+      />
       <SidebarInset className="h-full overflow-hidden">
         <div className="flex h-[calc(100dvh-1rem)]">
           <CalendarView

--- a/apps/web/src/components/calendar-view.tsx
+++ b/apps/web/src/components/calendar-view.tsx
@@ -134,6 +134,7 @@ export function CalendarView({
 
   useEffect(() => {
     enableScope("calendar");
+    enableScope("events");
   }, [enableScope]);
 
   return (

--- a/apps/web/src/components/calendar-view.tsx
+++ b/apps/web/src/components/calendar-view.tsx
@@ -134,7 +134,7 @@ export function CalendarView({
 
   useEffect(() => {
     enableScope("calendar");
-    enableScope("events");
+    enableScope("event");
   }, [enableScope]);
 
   return (

--- a/apps/web/src/components/delete-event-confirmation.tsx
+++ b/apps/web/src/components/delete-event-confirmation.tsx
@@ -1,0 +1,44 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface DeleteEventConfirmationProps {
+  onConfirm: () => void;
+  onCancel?: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteEventConfirmation({
+  onConfirm,
+  onCancel,
+  open,
+  onOpenChange,
+}: DeleteEventConfirmationProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. This will permanently delete the
+            event.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/event-calendar/hooks/use-optimistic-events.ts
+++ b/apps/web/src/components/event-calendar/hooks/use-optimistic-events.ts
@@ -12,7 +12,7 @@ export type Action =
   | { type: "draft"; event: DraftEvent }
   | { type: "update"; event: CalendarEvent }
   | { type: "select"; event: CalendarEvent }
-  | { type: "unselect"; eventId: string }
+  | { type: "unselect"; eventId?: string }
   | { type: "delete"; eventId: string };
 
 export type OptimisticAction =

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { VariantProps } from "class-variance-authority";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Omit<VariantProps<typeof buttonVariants>, "size">) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
+++ b/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
@@ -21,7 +21,6 @@ export const KEYBOARD_SHORTCUTS = {
   PREVIOUS_PERIOD: "p",
   TODAY: "t",
   CREATE_EVENT: "c",
-  DELETE_EVENT: "meta+backspace",
 } as const;
 
 export function CalendarHotkeys() {
@@ -58,14 +57,6 @@ export function CalendarHotkeys() {
       setCurrentDate((prevDate: Date) => navigateToPrevious(prevDate, view)),
     { scopes: ["calendar"] },
   );
-
-  useHotkeys(
-    KEYBOARD_SHORTCUTS.DELETE_EVENT,
-    (selectedEvent) => {
-      dispatchAction({ type: "delete", eventId: selectedEvent.id });
-    },
-    { scopes: ["calendar"], },
-  );  
 
   useHotkeys(
     KEYBOARD_SHORTCUTS.CREATE_EVENT,

--- a/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
+++ b/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
@@ -1,16 +1,12 @@
 "use client";
 
 import { useHotkeys } from "react-hotkeys-hook";
-import { Temporal } from "temporal-polyfill";
 
-import { useCalendarSettings } from "@/atoms";
 import {
   navigateToNext,
   navigateToPrevious,
 } from "@/components/event-calendar/utils/date-time";
-import { useSidebarWithSide } from "@/components/ui/sidebar";
 import { useCalendarState } from "@/hooks/use-calendar-state";
-import { createDraftEvent } from "../utils/calendar";
 
 export const KEYBOARD_SHORTCUTS = {
   MONTH: "m",
@@ -25,9 +21,6 @@ export const KEYBOARD_SHORTCUTS = {
 
 export function CalendarHotkeys() {
   const { view, setView, setCurrentDate } = useCalendarState();
-  const { open: rightSidebarOpen, setOpen: setRightSidebarOpen } =
-    useSidebarWithSide("right");
-  const settings = useCalendarSettings();
 
   useHotkeys(KEYBOARD_SHORTCUTS.MONTH, () => setView("month"), {
     scopes: ["calendar"],
@@ -56,22 +49,6 @@ export function CalendarHotkeys() {
     () =>
       setCurrentDate((prevDate: Date) => navigateToPrevious(prevDate, view)),
     { scopes: ["calendar"] },
-  );
-
-  useHotkeys(
-    KEYBOARD_SHORTCUTS.CREATE_EVENT,
-    () => {
-      const start = Temporal.Now.zonedDateTimeISO(settings.defaultTimeZone);
-
-      const end = start.add({ minutes: settings.defaultEventDuration });
-
-      if (!rightSidebarOpen) {
-        setRightSidebarOpen(true);
-      }
-
-      createDraftEvent({ start, end });
-    },
-    { scopes: ["events"] },
   );
 
   return null;

--- a/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
+++ b/apps/web/src/lib/hotkeys/calendar-hotkeys.ts
@@ -1,15 +1,15 @@
 "use client";
 
 import { useHotkeys } from "react-hotkeys-hook";
+import { Temporal } from "temporal-polyfill";
 
+import { useCalendarSettings } from "@/atoms";
 import {
   navigateToNext,
   navigateToPrevious,
 } from "@/components/event-calendar/utils/date-time";
 import { useSidebarWithSide } from "@/components/ui/sidebar";
 import { useCalendarState } from "@/hooks/use-calendar-state";
-import { useCalendarSettings } from "@/atoms";
-import { Temporal } from "temporal-polyfill";
 import { createDraftEvent } from "../utils/calendar";
 
 export const KEYBOARD_SHORTCUTS = {
@@ -65,7 +65,6 @@ export function CalendarHotkeys() {
 
       const end = start.add({ minutes: settings.defaultEventDuration });
 
-      
       if (!rightSidebarOpen) {
         setRightSidebarOpen(true);
       }

--- a/apps/web/src/lib/hotkeys/event-hotkeys.tsx
+++ b/apps/web/src/lib/hotkeys/event-hotkeys.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { Temporal } from "temporal-polyfill";
+
+import { useCalendarSettings } from "@/atoms";
+import { DeleteEventConfirmation } from "@/components/delete-event-confirmation";
+import type { Action } from "@/components/event-calendar/hooks/use-optimistic-events";
+import { useSidebarWithSide } from "@/components/ui/sidebar";
+import type { CalendarEvent, DraftEvent } from "@/lib/interfaces";
+import { createDraftEvent } from "@/lib/utils/calendar";
+
+export const KEYBOARD_SHORTCUTS = {
+  CREATE_EVENT: "c",
+  JOIN_MEETING: "j",
+  DELETE_EVENT: "backspace",
+  UNSELECT_EVENT: "esc",
+} as const;
+
+interface CalendarHotkeysProps {
+  dispatchAction: (action: Action) => void;
+  selectedEvent: CalendarEvent | DraftEvent | undefined;
+}
+
+export function EventHotkeys({
+  dispatchAction,
+  selectedEvent,
+}: CalendarHotkeysProps) {
+  const { open: rightSidebarOpen, setOpen: setRightSidebarOpen } =
+    useSidebarWithSide("right");
+  const settings = useCalendarSettings();
+
+  useHotkeys(
+    KEYBOARD_SHORTCUTS.CREATE_EVENT,
+    () => {
+      const start = Temporal.Now.zonedDateTimeISO(settings.defaultTimeZone);
+
+      const end = start.add({ minutes: settings.defaultEventDuration });
+
+      if (!rightSidebarOpen) {
+        setRightSidebarOpen(true);
+      }
+
+      const event = createDraftEvent({ start, end });
+
+      dispatchAction({
+        type: "draft",
+        event,
+      });
+    },
+    { scopes: ["event"] },
+  );
+
+  useHotkeys(
+    KEYBOARD_SHORTCUTS.JOIN_MEETING,
+    () => {
+      if (!selectedEvent || !selectedEvent.conference) {
+        return;
+      }
+
+      window.open(
+        selectedEvent.conference.joinUrl,
+        "_blank",
+        "noopener,noreferrer",
+      );
+    },
+    { scopes: ["event"] },
+  );
+
+  useHotkeys(
+    KEYBOARD_SHORTCUTS.DELETE_EVENT,
+    () => {
+      if (!selectedEvent) {
+        return;
+      }
+
+      setOpen(true);
+    },
+    { scopes: ["event"] },
+  );
+
+  useHotkeys(
+    KEYBOARD_SHORTCUTS.UNSELECT_EVENT,
+    () => {
+      dispatchAction({ type: "unselect" });
+    },
+    { scopes: ["event"] },
+  );
+
+  const [open, setOpen] = React.useState(false);
+
+  if (!selectedEvent) {
+    return null;
+  }
+
+  return (
+    <DeleteEventConfirmation
+      open={open}
+      onOpenChange={setOpen}
+      onConfirm={() => {
+        dispatchAction({ type: "delete", eventId: selectedEvent.id });
+      }}
+    />
+  );
+}

--- a/apps/web/src/providers/app-hotkey-provider.tsx
+++ b/apps/web/src/providers/app-hotkey-provider.tsx
@@ -11,7 +11,7 @@ interface AppHotkeyProviderProps {
 
 export function AppHotkeyProvider({ children }: AppHotkeyProviderProps) {
   return (
-    <HotkeysProvider initiallyActiveScopes={["calendar", "settings"]}>
+    <HotkeysProvider initiallyActiveScopes={["events", "calendar", "settings"]}>
       <CalendarHotkeys />
       {children}
     </HotkeysProvider>

--- a/apps/web/src/providers/app-hotkey-provider.tsx
+++ b/apps/web/src/providers/app-hotkey-provider.tsx
@@ -11,7 +11,7 @@ interface AppHotkeyProviderProps {
 
 export function AppHotkeyProvider({ children }: AppHotkeyProviderProps) {
   return (
-    <HotkeysProvider initiallyActiveScopes={["events", "calendar", "settings"]}>
+    <HotkeysProvider initiallyActiveScopes={["event", "calendar"]}>
       <CalendarHotkeys />
       {children}
     </HotkeysProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@hookform/resolvers": "^5.1.1",
         "@internationalized/date": "^3.8.2",
         "@number-flow/react": "^0.5.10",
+        "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-collapsible": "^1.1.11",
@@ -724,6 +725,8 @@
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
+
+    "@radix-ui/react-alert-dialog": ["@radix-ui/react-alert-dialog@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dialog": "1.1.14", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 


### PR DESCRIPTION
## What Changed

This PR enhances the calendar functionality by adding keyboard shortcuts for event creation and improving the integration of calendar state and settings:

- Added a new "Create Event" hotkey (`c`) that creates a draft event based on current time
- Enabled the "events" scope to support event-specific keyboard shortcuts
- Ensured the right sidebar automatically opens when creating a draft event
- Integrated calendar settings to determine default event duration

## Why This Change Matters

These enhancements significantly improve user productivity by:
  - Allowing quick event creation without leaving the keyboard
  - Streamlining the event creation workflow
  - Making the calendar interface more intuitive and efficient
  - Aligning with modern productivity app expectations for keyboard shortcuts
  
## Implementation Details

- Added `CREATE_EVENT` hotkey in `calendar-hotkeys.ts`
- Updated `CalendarHotkeys` component to handle the new shortcut
- Enabled "events" scope in `calendar-view.tsx`
- Added "events" to `initiallyActiveScopes` in `app-hotkey-provider.tsx`
- Integrated necessary utilities and hooks for draft event creation

## Type of Change
- [x] New feature
- [x] UI/UX update

## Related Areas
- [x] Calendar UI

## Notes for Reviewers

The implementation ensures that when a user presses `c`, a draft event is created with sensible defaults and the right sidebar opens automatically for editing, creating a smooth user experience.

https://share.cleanshot.com/GccPqXFB