### PR TITLE
Add etag field to calendar events

### DIFF
--- a/packages/api/src/providers/google-calendar.ts
+++ b/packages/api/src/providers/google-calendar.ts
@@ -139,11 +139,15 @@ export class GoogleCalendarProvider implements CalendarProvider {
         },
       );
 
-      const updatedEvent = await this.client.calendars.events.update(eventId, {
-        ...existingEvent,
-        calendarId: calendar.id,
-        ...toGoogleCalendarEvent(event),
-      });
+      const updatedEvent = await this.client.calendars.events.update(
+        eventId,
+        {
+          ...existingEvent,
+          calendarId: calendar.id,
+          ...toGoogleCalendarEvent(event),
+        },
+        event.etag ? { headers: { "If-Match": event.etag } } : undefined,
+      );
 
       return parseGoogleCalendarEvent({
         calendar,

--- a/packages/api/src/providers/google-calendar/utils.ts
+++ b/packages/api/src/providers/google-calendar/utils.ts
@@ -71,6 +71,7 @@ export function parseGoogleCalendarEvent({
   return {
     // ID should always be present if not defined Google Calendar will generate one
     id: event.id!,
+    etag: event.etag,
     title: event.summary!,
     description: event.description,
     start: isAllDay
@@ -102,6 +103,7 @@ export function toGoogleCalendarEvent(
     location: event.location,
     start: toGoogleCalendarDate(event.start),
     end: toGoogleCalendarDate(event.end),
+    ...("etag" in event && event.etag ? { etag: event.etag } : {}),
     // conferenceData: event.conference
     //   ? toGoogleCalendarConferenceData(event.conference)
     //   : undefined,

--- a/packages/api/src/providers/interfaces.ts
+++ b/packages/api/src/providers/interfaces.ts
@@ -21,6 +21,7 @@ export interface Calendar {
 
 export interface CalendarEvent {
   id: string;
+  etag?: string;
   title?: string;
   description?: string;
   start: Temporal.PlainDate | Temporal.Instant | Temporal.ZonedDateTime;

--- a/packages/api/src/providers/microsoft-calendar.ts
+++ b/packages/api/src/providers/microsoft-calendar.ts
@@ -144,9 +144,17 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
     event: UpdateEventInput,
   ): Promise<CalendarEvent> {
     return this.withErrorHandler("updateEvent", async () => {
-      const updatedEvent: MicrosoftEvent = await this.graphClient
-        .api(`${calendarPath(calendar.id)}/events/${eventId}`)
-        .patch(toMicrosoftEvent(event));
+      let request = this.graphClient.api(
+        `${calendarPath(calendar.id)}/events/${eventId}`,
+      );
+
+      if (event.etag) {
+        request = request.header("If-Match", event.etag);
+      }
+
+      const updatedEvent: MicrosoftEvent = await request.patch(
+        toMicrosoftEvent(event),
+      );
 
       return parseMicrosoftEvent({
         event: updatedEvent,

--- a/packages/api/src/providers/microsoft-calendar/utils.ts
+++ b/packages/api/src/providers/microsoft-calendar/utils.ts
@@ -112,6 +112,7 @@ export function parseMicrosoftEvent({
 
   return {
     id: event.id!,
+    etag: event.changeKey ?? undefined,
     title: event.subject!,
     description: event.bodyPreview ?? undefined,
     start: isAllDay

--- a/packages/api/src/schemas/events.ts
+++ b/packages/api/src/schemas/events.ts
@@ -60,6 +60,7 @@ export const createEventInputSchema = z.object({
 
 export const updateEventInputSchema = createEventInputSchema.extend({
   id: z.string(),
+  etag: z.string().optional(),
   conference: conferenceSchema.optional(),
   metadata: z.union([microsoftMetadataSchema, googleMetadataSchema]).optional(),
 });

--- a/packages/db/src/schema/calendars.ts
+++ b/packages/db/src/schema/calendars.ts
@@ -66,6 +66,7 @@ export const events = pgTable(
     url: text("url"),
 
     syncToken: text("sync_token"),
+    etag: text("etag"),
 
     calendarId: text("calendar_id")
       .notNull()


### PR DESCRIPTION
## Summary
- store ETag/change key in the `CalendarEvent` interface
- parse `etag` from Google Calendar events
- parse `changeKey` from Microsoft events
- persist `etag` in the events database table
- include `etag` in update event schema
- send `etag` as `If-Match` header when updating events

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68762ac7b7cc832bb39f0bbfe49fe1ac