### PR TITLE
feat(api): retrieve user attendee responses for events

### DIFF
--- a/apps/web/src/components/event-calendar/event-context-menu.tsx
+++ b/apps/web/src/components/event-calendar/event-context-menu.tsx
@@ -5,6 +5,8 @@ import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { useQuery } from "@tanstack/react-query";
 import { CheckIcon } from "lucide-react";
 
+import type { AttendeeStatus } from "@repo/api/providers/interfaces";
+
 import { CalendarEvent } from "@/components/event-calendar/types";
 import {
   ContextMenu,
@@ -101,9 +103,20 @@ export function EventContextMenu({
   children,
   dispatchAction,
 }: EventContextMenuProps) {
-  const responseStatus = React.useMemo(() => {
-    return event.attendees?.find((attendee) => attendee.email === " ")?.status;
-  }, [event]);
+  const responseStatus = event.response?.status;
+
+  const handleRespond = (status: AttendeeStatus) => {
+    if (!responseStatus) return;
+    if (status === responseStatus) return;
+
+    dispatchAction({
+      type: "update",
+      event: {
+        ...event,
+        response: { status },
+      },
+    });
+  };
 
   const handleDelete = () => {
     dispatchAction({ type: "delete", eventId: event.id });
@@ -123,6 +136,7 @@ export function EventContextMenu({
           className="font-medium"
           checked={responseStatus === "accepted"}
           disabled={!responseStatus}
+          onSelect={() => handleRespond("accepted")}
         >
           Going
           <KeyboardShortcut className="ml-auto bg-transparent text-muted-foreground">
@@ -134,6 +148,7 @@ export function EventContextMenu({
           className="font-medium"
           checked={responseStatus === "tentative"}
           disabled={!responseStatus}
+          onSelect={() => handleRespond("tentative")}
         >
           Maybe
           <KeyboardShortcut className="ml-auto bg-transparent text-muted-foreground">
@@ -145,6 +160,7 @@ export function EventContextMenu({
           className="font-medium"
           checked={responseStatus === "declined"}
           disabled={!responseStatus}
+          onSelect={() => handleRespond("declined")}
         >
           Not going
           <KeyboardShortcut className="ml-auto bg-transparent text-muted-foreground">

--- a/apps/web/src/components/event-calendar/event-context-menu.tsx
+++ b/apps/web/src/components/event-calendar/event-context-menu.tsx
@@ -106,8 +106,9 @@ export function EventContextMenu({
   const responseStatus = event.response?.status;
 
   const handleRespond = (status: AttendeeStatus) => {
-    if (!responseStatus) return;
-    if (status === responseStatus) return;
+    if (!responseStatus || status === responseStatus) {
+      return;
+    }
 
     dispatchAction({
       type: "update",

--- a/packages/api/src/providers/google-calendar/utils.ts
+++ b/packages/api/src/providers/google-calendar/utils.ts
@@ -67,6 +67,17 @@ export function parseGoogleCalendarEvent({
   event,
 }: ParsedGoogleCalendarEventOptions): CalendarEvent {
   const isAllDay = !event.start?.dateTime;
+  const selfAttendee = event.attendees?.find((a) => a.self);
+  const response = selfAttendee
+    ? {
+        status: parseGoogleCalendarAttendeeStatus(
+          selfAttendee.responseStatus as GoogleCalendarEventAttendeeResponseStatus,
+        ),
+        comment: selfAttendee.comment,
+      }
+    : event.organizer?.self
+      ? { status: "accepted" as const }
+      : undefined;
 
   return {
     // ID should always be present if not defined Google Calendar will generate one
@@ -89,6 +100,7 @@ export function parseGoogleCalendarEvent({
     calendarId: calendar.id,
     readOnly: calendar.readOnly,
     conference: parseGoogleCalendarConferenceData(event),
+    ...(response && { response }),
   };
 }
 
@@ -378,6 +390,7 @@ export function parseGoogleCalendarAttendee(
       attendee.responseStatus as GoogleCalendarEventAttendeeResponseStatus,
     ),
     type: parseGoogleCalendarAttendeeType(attendee),
+    comment: attendee.comment,
     additionalGuests: attendee.additionalGuests,
   };
 }

--- a/packages/api/src/providers/interfaces.ts
+++ b/packages/api/src/providers/interfaces.ts
@@ -54,6 +54,12 @@ export interface Attendee {
   additionalGuests?: number; // Google only
 }
 
+export interface ResponseToEventInput {
+  status: "accepted" | "tentative" | "declined" | "unknown";
+  comment?: string;
+  sendUpdate: boolean;
+}
+
 export type AttendeeStatus = Attendee["status"];
 
 export interface CalendarProvider {
@@ -86,10 +92,7 @@ export interface CalendarProvider {
   responseToEvent(
     calendarId: string,
     eventId: string,
-    response: {
-      status: "accepted" | "tentative" | "declined";
-      comment?: string;
-    },
+    response: ResponseToEventInput,
   ): Promise<void>;
 }
 

--- a/packages/api/src/providers/interfaces.ts
+++ b/packages/api/src/providers/interfaces.ts
@@ -35,6 +35,11 @@ export interface CalendarEvent {
   providerId: "google" | "microsoft";
   accountId: string;
   calendarId: string;
+  /** Current user's response status for this event */
+  response?: {
+    status: AttendeeStatus;
+    comment?: string;
+  };
   metadata?: Record<string, unknown>;
   conference?: Conference;
 }

--- a/packages/api/src/providers/microsoft-calendar/utils.ts
+++ b/packages/api/src/providers/microsoft-calendar/utils.ts
@@ -110,6 +110,12 @@ export function parseMicrosoftEvent({
     throw new Error("Event start or end is missing");
   }
 
+  const responseStatus = event.responseStatus?.response
+    ? parseMicrosoftAttendeeStatus(event.responseStatus.response)
+    : event.isOrganizer
+      ? ("accepted" as const)
+      : undefined;
+
   return {
     id: event.id!,
     title: event.subject!,
@@ -131,6 +137,7 @@ export function parseMicrosoftEvent({
     calendarId: calendar.id,
     readOnly: calendar.readOnly,
     conference: parseMicrosoftConference(event),
+    ...(responseStatus && { response: { status: responseStatus } }),
     metadata: {
       ...(event.originalStartTimeZone
         ? {

--- a/packages/api/src/providers/microsoft-calendar/utils.ts
+++ b/packages/api/src/providers/microsoft-calendar/utils.ts
@@ -99,6 +99,33 @@ interface ParseMicrosoftEventOptions {
   event: MicrosoftEvent;
 }
 
+function parseResponseStatus(
+  event: MicrosoftEvent,
+): AttendeeStatus | undefined {
+  const organizerIsAttendee =
+    event.attendees?.some(
+      (attendee) => attendee.status?.response === "organizer",
+    ) ?? false;
+
+  if (
+    !event.attendees ||
+    !organizerIsAttendee ||
+    event.attendees.length === 0
+  ) {
+    return undefined;
+  }
+
+  const hasOtherAttendees = organizerIsAttendee && event.attendees.length > 1;
+
+  if (!hasOtherAttendees) {
+    return undefined;
+  }
+
+  return event.responseStatus?.response
+    ? parseMicrosoftAttendeeStatus(event.responseStatus.response)
+    : undefined;
+}
+
 export function parseMicrosoftEvent({
   accountId,
   calendar,
@@ -110,11 +137,7 @@ export function parseMicrosoftEvent({
     throw new Error("Event start or end is missing");
   }
 
-  const responseStatus = event.responseStatus?.response
-    ? parseMicrosoftAttendeeStatus(event.responseStatus.response)
-    : event.isOrganizer
-      ? ("accepted" as const)
-      : undefined;
+  const responseStatus = parseResponseStatus(event);
 
   return {
     id: event.id!,
@@ -298,15 +321,11 @@ export function eventResponseStatusPath(
 function parseMicrosoftAttendeeStatus(
   status: MicrosoftEventAttendeeResponseStatus["response"],
 ): AttendeeStatus {
-  if (
-    status === "notResponded" ||
-    status === "none" ||
-    status === "organizer"
-  ) {
+  if (status === "notResponded" || status === "none") {
     return "unknown";
   }
 
-  if (status === "accepted") {
+  if (status === "accepted" || status === "organizer") {
     return "accepted";
   }
 

--- a/packages/api/src/routers/events.ts
+++ b/packages/api/src/routers/events.ts
@@ -119,10 +119,20 @@ export const eventsRouter = createTRPCRouter({
         });
       }
 
+      const { response, ...updateInput } = input;
+
+      if (response) {
+        await provider.client.responseToEvent(
+          input.calendarId,
+          input.id,
+          response,
+        );
+      }
+
       const event = await provider.client.updateEvent(
         calendar,
-        input.id,
-        input,
+        updateInput.id,
+        updateInput,
       );
 
       return { event };

--- a/packages/api/src/routers/events.ts
+++ b/packages/api/src/routers/events.ts
@@ -119,20 +119,10 @@ export const eventsRouter = createTRPCRouter({
         });
       }
 
-      const { response, ...updateInput } = input;
-
-      if (response) {
-        await provider.client.responseToEvent(
-          input.calendarId,
-          input.id,
-          response,
-        );
-      }
-
       const event = await provider.client.updateEvent(
         calendar,
-        updateInput.id,
-        updateInput,
+        input.id,
+        input,
       );
 
       return { event };
@@ -168,8 +158,9 @@ export const eventsRouter = createTRPCRouter({
         calendarId: z.string(),
         eventId: z.string(),
         response: z.object({
-          status: z.enum(["accepted", "tentative", "declined"]),
+          status: z.enum(["accepted", "tentative", "declined", "unknown"]),
           comment: z.string().optional(),
+          sendUpdate: z.boolean().default(true),
         }),
       }),
     )
@@ -185,11 +176,11 @@ export const eventsRouter = createTRPCRouter({
         });
       }
 
-      await provider.client.responseToEvent(
-        input.calendarId,
-        input.eventId,
-        input.response,
-      );
+      await provider.client.responseToEvent(input.calendarId, input.eventId, {
+        status: input.response.status,
+        comment: input.response.comment,
+        sendUpdate: input.response.sendUpdate,
+      });
 
       return { success: true };
     }),

--- a/packages/api/src/schemas/events.ts
+++ b/packages/api/src/schemas/events.ts
@@ -61,6 +61,12 @@ export const updateEventInputSchema = createEventInputSchema.extend({
   id: z.string(),
   conference: conferenceSchema.optional(),
   metadata: z.union([microsoftMetadataSchema, googleMetadataSchema]).optional(),
+  response: z
+    .object({
+      status: z.enum(["accepted", "tentative", "declined"]),
+      comment: z.string().optional(),
+    })
+    .optional(),
 });
 
 export type CreateEventInput = z.infer<typeof createEventInputSchema>;

--- a/packages/api/src/schemas/events.ts
+++ b/packages/api/src/schemas/events.ts
@@ -63,8 +63,9 @@ export const updateEventInputSchema = createEventInputSchema.extend({
   metadata: z.union([microsoftMetadataSchema, googleMetadataSchema]).optional(),
   response: z
     .object({
-      status: z.enum(["accepted", "tentative", "declined"]),
+      status: z.enum(["accepted", "tentative", "declined", "unknown"]),
       comment: z.string().optional(),
+      sendUpdate: z.boolean().default(false),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary
- add `response` field to `CalendarEvent`
- derive the current user's response when parsing Google and Microsoft events
- simplify event context menu to read event.response

## Testing
- `bun run format`
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68762a5e1414832bb80362a189cbdb42