### PR TITLE
fix(web): resolve date pickers not responding to first interaction

### DIFF
--- a/apps/web/src/components/date-input.tsx
+++ b/apps/web/src/components/date-input.tsx
@@ -162,7 +162,6 @@ export function DateInput({
             setOpen(true);
           }}
           onChange={(e) => onInputChange(e.target.value)}
-          onBlur={(e) => onInput(e.target.value)}
           onKeyDown={(e) => {
             if (e.key !== "Enter") {
               return;


### PR DESCRIPTION
## Description

Setting date would take two click which is mentioned in issue(#234). This was caused due to onBlur() use in Input component.

## Screenshots / Recordings


https://github.com/user-attachments/assets/d079b865-cfaf-452e-848d-2a21a41ea4e4

