### PR TITLE
fix: contribution guide link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@ Add screenshots or recordings here to help reviewers understand your changes.
 
 ## Checklist
 
-- [ ] I’ve read the [CONTRIBUTING](../CONTRIBUTING.md) guide
+- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
 - [ ] My code works and is understandable and follows the project's style guidelines
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in complex areas


### PR DESCRIPTION
## Description

Fixes the link to the contribution guide in the pr template.

## Checklist

- [x] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [x] My code works and is understandable and follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] Any dependent changes are merged and published
