### PR TITLE
fix(web): remove aspect-square from today button

### DIFF
--- a/apps/web/src/components/event-calendar/calendar-navigation.tsx
+++ b/apps/web/src/components/event-calendar/calendar-navigation.tsx
@@ -51,7 +51,7 @@ export function CalendarNavigation() {
       </div>
       <Button
         variant="outline"
-        className="aspect-square h-8 @max-md/header:hidden"
+        className="h-8 @max-md/header:hidden"
         onClick={handleToday}
       >
         Today


### PR DESCRIPTION
## Description

Firefox and chrome treat aspect-square differently and we dont even need that class on there so its removed.

Closes #259 

## Screenshots / Recordings

<img width="306" height="128" alt="image" src="https://github.com/user-attachments/assets/050350c5-a1e2-41a3-902a-2be6cbb40da7" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [x] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Checklist

- [x] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [x] My code works and is understandable and follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] Any dependent changes are merged and published
