### PR TITLE
chore(api): add sentry middleware for tRPC

### DIFF
--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -8,6 +8,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 0.001,
+  normalizeDepth: 7,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 0.001,
+  normalizeDepth: 7,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 0.001,
+  normalizeDepth: 7,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
+    "@sentry/node": "^9.35.0",
     "@trpc/server": "^11.4.3",
     "better-auth": "1.3.1",
     "next": "^15.4.2",


### PR DESCRIPTION
## Summary
- instrument trpc public and protected procedures with Sentry middleware
- declare Sentry in api package peer dependencies
- configure Sentry to capture deeper context
- avoid capturing RPC input in Sentry by disabling attachRpcInput

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b35968b00832ba6a5edabc2c30708