### PR TITLE
chore(api): mark special event types as read only

### DIFF
--- a/packages/api/src/providers/calendars/google-calendar/events.ts
+++ b/packages/api/src/providers/calendars/google-calendar/events.ts
@@ -124,7 +124,11 @@ export function parseGoogleCalendarEvent({
     providerId: "google",
     accountId,
     calendarId: calendar.id,
-    readOnly: calendar.readOnly,
+    readOnly:
+      calendar.readOnly ||
+      ["birthday", "focusTime", "outOfOffice", "workingLocation"].includes(
+        event.eventType ?? "",
+      ),
     conference: parseGoogleCalendarConferenceData(event),
     ...(response && { response }),
     ...(recurrence && { recurrence }),


### PR DESCRIPTION
## Summary
- mark birthday, focusTime, outOfOffice, and workingLocation Google Calendar events as read-only

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba76443a4832bb2ed5f23dbf353e3