### PR TITLE
fix(repo): add missing env variables to turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,9 @@
         "SENTRY_PROJECT",
         "SENTRY_ORG",
         "MARBLE_WORKSPACE_KEY",
-        "MARBLE_API_URL"
+        "MARBLE_API_URL",
+        "UNKEY_ROOT_KEY",
+        "NEXT_RUNTIME"
       ],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
@@ -61,7 +63,9 @@
         "SENTRY_PROJECT",
         "SENTRY_ORG",
         "MARBLE_WORKSPACE_KEY",
-        "MARBLE_API_URL"
+        "MARBLE_API_URL",
+        "UNKEY_ROOT_KEY",
+        "NEXT_RUNTIME"
       ]
     },
     "lint": {


### PR DESCRIPTION
## Summary
- expose `UNKEY_ROOT_KEY` and `NEXT_RUNTIME` for turbo build and dev

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e481c1378832b9c6258569e767194