### PR TITLE
fix: update docker scripts to use Docker Compose v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "format": "prettier --write \"**/*.{ts,tsx,css,md}\"",
-    "docker:up": "docker-compose up -d",
-    "docker:down": "docker-compose down",
-    "docker:clean": "docker-compose down -v",
+    "docker:up": "docker compose up -d",
+    "docker:down": "docker compose down",
+    "docker:clean": "docker compose down -v",
     "db:generate": "turbo run db:generate",
     "db:migrate": "dotenv -- turbo run db:migrate",
     "db:push": "dotenv -- turbo run db:push",
@@ -23,5 +23,9 @@
     "turbo": "^2.5.5"
   },
   "packageManager": "bun@1.2.18",
-  "workspaces": ["apps/*", "packages/*", "tooling/*"]
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "tooling/*"
+  ]
 }


### PR DESCRIPTION
Fixes #343 

On Linux, running `bun run docker:up` fails with `docker-compose v1` because
the `name:` field in docker-compose.yml requires Docker Compose v2.

This PR updates the scripts in package.json to use `docker compose` instead
of `docker-compose`.

Tested locally and works as expected :)