### PR TITLE
fix(web): resolve draft events positioned incorrect after dragging

### DIFF
--- a/apps/web/src/components/calendar/flows/update-event/update-queue.ts
+++ b/apps/web/src/components/calendar/flows/update-event/update-queue.ts
@@ -4,7 +4,7 @@ import { assign, fromPromise, setup } from "xstate";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Guard } from "xstate/guards";
 
-import { CalendarEvent } from "@repo/api/interfaces";
+import type { CalendarEvent } from "@/lib/interfaces";
 
 export interface UpdateQueueRequest {
   event: CalendarEvent;


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes incorrect positioning of draft events after dragging by clearing stale optimistic updates and using a dedicated draft optimistic action. Drag-and-drop now places drafts correctly with stable optimistic rendering.

- **Bug Fixes**
  - Remove existing draft optimistic actions for the event before adding a new one.
  - Use a "draft" optimistic action for drafts; keep "update" for non-drafts.
  - Preserve queue behavior and optimisticId return for callers.

<!-- End of auto-generated description by cubic. -->

