### PR TITLE
chore(web): add default calendar color to draft previews

### DIFF
--- a/apps/web/src/components/calendar/event/drag-preview.tsx
+++ b/apps/web/src/components/calendar/event/drag-preview.tsx
@@ -2,16 +2,20 @@ import * as React from "react";
 import { motion } from "motion/react";
 
 import { cn } from "@/lib/utils";
+import { useDefaultCalendar } from "../hooks/use-default-calendar";
 
 type DragPreviewProps = React.ComponentProps<typeof motion.div>;
 
-export function DragPreview({ className, ...props }: DragPreviewProps) {
+export function DragPreview({ className, style, ...props }: DragPreviewProps) {
+  const { color } = useDefaultCalendar();
+
   return (
     <motion.div
       className={cn(
-        "absolute inset-[2px] z-[1000] rounded-sm bg-primary/10 transition-all duration-[10ms]",
+        "absolute inset-[2px] z-1000 rounded-sm bg-event transition-all duration-[10ms]",
         className,
       )}
+      style={{ ...style, "--calendar-color": color } as React.CSSProperties}
       {...props}
     ></motion.div>
   );

--- a/apps/web/src/components/calendar/hooks/use-default-calendar.ts
+++ b/apps/web/src/components/calendar/hooks/use-default-calendar.ts
@@ -16,7 +16,7 @@ export function useDefaultCalendar() {
   }, [query.data?.defaultCalendar]);
 
   return {
-    ...query.data?.defaultCalendar,
+    ...(query.data?.defaultCalendar ?? {}),
     color,
   };
 }

--- a/apps/web/src/components/calendar/hooks/use-default-calendar.ts
+++ b/apps/web/src/components/calendar/hooks/use-default-calendar.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { calendarColorVariable } from "@/lib/css";
+import { useTRPC } from "@/lib/trpc/client";
+
+export function useDefaultCalendar() {
+  const trpc = useTRPC();
+  const query = useQuery(trpc.calendars.list.queryOptions());
+  const color = React.useMemo(() => {
+    if (!query.data?.defaultCalendar) {
+      return "var(--color-muted-foreground)";
+    }
+
+    return `var(${calendarColorVariable(query.data?.defaultCalendar?.accountId, query.data?.defaultCalendar?.id)}, var(--color-muted-foreground))`;
+  }, [query.data?.defaultCalendar]);
+
+  return {
+    ...query.data?.defaultCalendar,
+    color,
+  };
+}


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use the default calendar’s color for the drag preview when creating event drafts. This makes the preview match the calendar’s theme.

- **New Features**
  - Added useDefaultCalendar hook to fetch the default calendar and expose its CSS color variable.
  - Updated DragPreview to use bg-event and set --calendar-color via style for accurate tinting.

<!-- End of auto-generated description by cubic. -->

