### PR TITLE
chore(web): improve tRPC context creation and MCP sessions

### DIFF
--- a/packages/api/src/routers/calendars.ts
+++ b/packages/api/src/routers/calendars.ts
@@ -1,6 +1,8 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod/v3";
 
+import { auth } from "@repo/auth/server";
+
 import { assignColor } from "../providers/calendars/colors";
 import {
   calendarProcedure,
@@ -193,7 +195,9 @@ export const calendarsRouter = createTRPCRouter({
         });
       }
 
-      await ctx.authContext.internalAdapter.updateUser(ctx.user.id, {
+      const authContext = await auth.$context;
+
+      await authContext.internalAdapter.updateUser(ctx.user.id, {
         defaultCalendarId: calendar.id,
         defaultAccountId: input.accountId,
       });

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "exports": {
     "./client": "./src/client.ts",
-    "./server": "./src/server.ts"
+    "./server": "./src/server.ts",
+    "./server/mcp": "./src/server/mcp.ts"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { apiKey, mcp, openAPI } from "better-auth/plugins";
+import { apiKey, mcp } from "better-auth/plugins";
 
 import { db } from "@repo/db";
 import type { account as accountTable } from "@repo/db/schema";

--- a/packages/auth/src/server/mcp.ts
+++ b/packages/auth/src/server/mcp.ts
@@ -1,0 +1,27 @@
+import { auth, type Session } from "@repo/auth/server";
+import { db } from "@repo/db";
+
+export async function getMcpSession(headers: Headers): Promise<Session | null> {
+  const oAuthSession = await auth.api.getMcpSession({
+    headers,
+  });
+
+  if (!oAuthSession) {
+    return null;
+  }
+
+  const result = await db.query.session.findFirst({
+    where: (table, { eq }) => eq(table.userId, oAuthSession.userId),
+    with: {
+      user: true,
+    },
+  });
+
+  if (!result) {
+    return null;
+  }
+
+  const { user, ...session } = result;
+
+  return { session, user };
+}


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Simplified tRPC context and MCP authentication by centralizing MCP session lookup and allowing explicit sessions in context creation. This removes duplication in the MCP route, clarifies auth boundaries, and keeps rate-limiting consistent.

- **Refactors**
  - Added getMcpSession(headers) in @repo/auth/server/mcp and exported it.
  - apps/web MCP route: removed withMcpAuth; use getMcpSession and pass session into tRPC; simplified verboseLogs config.
  - tRPC context: accepts optional session; builds ctx without authContext; protectedProcedure asserts non-null session/user; rateLimit uses user id or IP.
  - calendars router: fetches auth.$context locally before updateUser.

- **Migration**
  - Replace any ctx.authContext usage with await auth.$context where needed.
  - For MCP endpoints, pass session to createContext to avoid redundant lookups.

<!-- End of auto-generated description by cubic. -->

