### PR TITLE
fix(web): remove unused mobile nav links

### DIFF
--- a/apps/web/src/components/landing-page/header.tsx
+++ b/apps/web/src/components/landing-page/header.tsx
@@ -27,12 +27,12 @@ const socialItems = [
   },
 ];
 
-const menuItems = [
-  { name: "Features", href: "#link" },
-  { name: "Solution", href: "#link" },
-  { name: "Pricing", href: "#link" },
-  { name: "About", href: "#link" },
-];
+// const menuItems = [
+//   { name: "Features", href: "#link" },
+//   { name: "Solution", href: "#link" },
+//   { name: "Pricing", href: "#link" },
+//   { name: "About", href: "#link" },
+// ];
 
 export function Header() {
   const [menuState, setMenuState] = React.useState(false);
@@ -95,7 +95,7 @@ export function Header() {
             </div>
 
             <div className="mb-6 hidden w-full flex-wrap items-center justify-end space-y-8 rounded-3xl border bg-background p-6 shadow-2xl shadow-zinc-300/20 in-data-[state=active]:block md:flex-nowrap lg:m-0 lg:flex lg:w-fit lg:gap-6 lg:space-y-0 lg:border-transparent lg:bg-transparent lg:p-0 lg:shadow-none lg:in-data-[state=active]:flex dark:shadow-none dark:lg:bg-transparent">
-              <div className="lg:hidden">
+              {/* <div className="lg:hidden">
                 <ul className="space-y-6 text-base">
                   {menuItems.map((item, index) => (
                     <li key={index}>
@@ -108,7 +108,7 @@ export function Header() {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </div> */}
               <div className="flex w-full flex-col space-y-6 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
                 <div
                   className={cn(


### PR DESCRIPTION
## Summary
- comment out mobile nav items Features, Solution, Pricing, and About on landing page

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd647bcf88832b800d130cdc225de3
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hide mobile nav links (Features, Solution, Pricing, About) on the landing page to remove unused items on small screens. Commented out the menuItems array and the mobile-only list rendering in the header; desktop actions stay the same.

<!-- End of auto-generated description by cubic. -->

