### PR TITLE
feat(web): optimize event re-render on select

### DIFF
--- a/apps/web/src/atoms/selected-events.ts
+++ b/apps/web/src/atoms/selected-events.ts
@@ -11,3 +11,11 @@ export const selectedEventIdsAtom = atom<string[]>([]);
 export const formEventAtom = atom<CalendarEvent | DraftEvent | undefined>(
   undefined,
 );
+
+export const isEventSelected = (eventId: string) =>
+  atom((get) => {
+    const events = get(selectedEventsAtom);
+    return events.some((event) => {
+      return event.id === eventId;
+    });
+  });

--- a/apps/web/src/components/calendar/event/event-item.tsx
+++ b/apps/web/src/components/calendar/event/event-item.tsx
@@ -5,7 +5,7 @@ import { useAtomValue } from "jotai";
 import { Temporal } from "temporal-polyfill";
 
 import { calendarSettingsAtom } from "@/atoms/calendar-settings";
-import { selectedEventsAtom } from "@/atoms/selected-events";
+import { isEventSelected } from "@/atoms/selected-events";
 import {
   getBorderRadiusClasses,
   getContentPaddingClasses,
@@ -97,9 +97,11 @@ export function EventItem({
   const displayStart = currentTime ?? item.start;
   const displayEnd = currentTime ?? item.end;
 
-  const selectedEvents = useAtomValue(selectedEventsAtom);
-
-  const isSelected = selectedEvents.some((e) => e.id === item.event.id);
+  const isSelectedAtom = React.useMemo(
+    () => isEventSelected(item.event.id),
+    [item.event.id],
+  );
+  const isSelected = useAtomValue(isSelectedAtom);
 
   const duration = React.useMemo(() => {
     return displayStart.until(displayEnd).total({ unit: "minute" });


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Optimize calendar event selection rendering by subscribing each EventItem to its own selection state. This reduces unnecessary re-renders when selecting/deselecting events.

- **Refactors**
  - Added isEventSelected(eventId) derived atom to compute selection per event.
  - Updated EventItem to memoize and read only its own selection atom instead of the full selectedEventsAtom.

<!-- End of auto-generated description by cubic. -->

