### PR TITLE
fix(web): resolve state machine rollback trigger on draft update

### DIFF
--- a/apps/web/src/components/calendar/flows/create-event/create-queue-provider.tsx
+++ b/apps/web/src/components/calendar/flows/create-event/create-queue-provider.tsx
@@ -25,9 +25,7 @@ export function CreateQueueProvider({ children }: CreateQueueProviderProps) {
     async (item: CreateQueueItem) => {
       createMutation.mutate(item.event, {
         onSuccess: () => {
-          if (item.onSuccess) {
-            item.onSuccess();
-          }
+          item.onSuccess?.();
         },
         onSettled: () => {
           removeOptimisticAction(item.optimisticId);

--- a/apps/web/src/components/calendar/flows/create-event/create-queue.ts
+++ b/apps/web/src/components/calendar/flows/create-event/create-queue.ts
@@ -4,7 +4,7 @@ import { assign, fromPromise, setup } from "xstate";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Guard } from "xstate/guards";
 
-import { CalendarEvent } from "@repo/api/interfaces";
+import type { CalendarEvent } from "@/lib/interfaces";
 
 export interface CreateQueueRequest {
   event: CalendarEvent;

--- a/apps/web/src/components/calendar/flows/create-event/utils.ts
+++ b/apps/web/src/components/calendar/flows/create-event/utils.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "temporal-polyfill";
 
-import { CalendarEvent } from "@repo/api/interfaces";
+import type { CalendarEvent } from "@/lib/interfaces";
 
 function isStartDateTimeEqual(
   event: CalendarEvent,

--- a/apps/web/src/components/calendar/flows/delete-event/delete-queue.ts
+++ b/apps/web/src/components/calendar/flows/delete-event/delete-queue.ts
@@ -4,7 +4,7 @@ import { assign, fromPromise, setup } from "xstate";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Guard } from "xstate/guards";
 
-import { CalendarEvent } from "@repo/api/interfaces";
+import type { CalendarEvent } from "@/lib/interfaces";
 
 export interface DeleteQueueRequest {
   event: CalendarEvent;

--- a/apps/web/src/components/calendar/flows/event-form/utils.ts
+++ b/apps/web/src/components/calendar/flows/event-form/utils.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "temporal-polyfill";
 
-import { CalendarEvent } from "@repo/api/interfaces";
+import type { CalendarEvent } from "@/lib/interfaces";
 
 function isStartDateTimeEqual(
   event: CalendarEvent,

--- a/apps/web/src/components/calendar/flows/update-event/use-update-action.tsx
+++ b/apps/web/src/components/calendar/flows/update-event/use-update-action.tsx
@@ -143,7 +143,6 @@ export function usePartialUpdateAction() {
 
 export function useUpdateAction() {
   const actorRef = UpdateQueueContext.useActorRef();
-
   const updateOptimisticUpdate = useOptimisticUpdateAction();
 
   return React.useCallback(

--- a/apps/web/src/components/calendar/flows/update-event/utils.ts
+++ b/apps/web/src/components/calendar/flows/update-event/utils.ts
@@ -1,7 +1,6 @@
 import { Temporal } from "temporal-polyfill";
 
-import { CalendarEvent } from "@repo/api/interfaces";
-
+import type { CalendarEvent } from "@/lib/interfaces";
 import { isUserOnlyAttendee } from "@/lib/utils/events";
 
 function isStartDateTimeEqual(


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes rollback when updating or deleting draft calendar events. Uses a DB lookup to find the previous event and gracefully handles drafts to keep optimistic UI stable.

- **Bug Fixes**
  - Use getEventById instead of react-query cache to fetch the previous event.
  - If previous event is missing and the item is a draft:
    - Update: call onSuccess and exit (no mutation).
    - Delete: remove optimistic action and exit.
  - Pass notify directly as sendUpdate to mutations.

- **Refactors**
  - Switch CalendarEvent type imports to "@/lib/interfaces".
  - Use optional chaining for callbacks (onSuccess?.()).
  - Remove unused react-query code from update/delete queue providers.

<!-- End of auto-generated description by cubic. -->

