### PR TITLE
feat(api): add calendar and event sync endpoints

### DIFF
--- a/packages/api/src/interfaces/calendars.ts
+++ b/packages/api/src/interfaces/calendars.ts
@@ -12,6 +12,7 @@ export interface Calendar {
   providerAccountId: string;
   color?: string;
   readOnly: boolean;
+  syncToken: string | null;
 }
 
 export interface FreeBusySlot {

--- a/packages/api/src/interfaces/events.ts
+++ b/packages/api/src/interfaces/events.ts
@@ -32,6 +32,22 @@ export interface CalendarEvent {
   recurringEventId?: string;
 }
 
+export type CalendarEventSyncItem =
+  | {
+      status: "updated";
+      event: CalendarEvent;
+    }
+  | {
+      status: "deleted";
+      event: {
+        id: string;
+        calendarId: string;
+        accountId: string;
+        providerId: "google" | "microsoft";
+        providerAccountId?: string;
+      };
+    };
+
 export interface ConferenceEntryPoint {
   joinUrl: {
     label?: string;

--- a/packages/api/src/providers/calendars/google-calendar/calendars.ts
+++ b/packages/api/src/providers/calendars/google-calendar/calendars.ts
@@ -10,12 +10,8 @@ export function parseGoogleCalendarCalendarListEntry({
   accountId,
   entry,
 }: ParsedGoogleCalendarCalendarListEntryOptions): Calendar {
-  if (!entry.id) {
-    throw new Error("Calendar ID is missing");
-  }
-
   return {
-    id: entry.id,
+    id: entry.id!,
     name: entry.summaryOverride ?? entry.summary!,
     description: entry.description,
     etag: entry.etag,
@@ -28,5 +24,6 @@ export function parseGoogleCalendarCalendarListEntry({
     accountId,
     providerAccountId: accountId,
     color: entry.backgroundColor,
+    syncToken: null,
   };
 }

--- a/packages/api/src/providers/calendars/google-calendar/events.ts
+++ b/packages/api/src/providers/calendars/google-calendar/events.ts
@@ -221,6 +221,43 @@ function toGoogleCalendarAttendees(
   return attendees.map(toGoogleCalendarAttendee);
 }
 
+function recurrences(event: CreateEventInput | UpdateEventInput) {
+  // TODO: how to handle recurrence when the time zone is changed (i.e. until, rDate, exDate).
+  if (event.recurrence === null) {
+    return [];
+  }
+
+  if (!event.recurrence) {
+    return undefined;
+  }
+
+  return toRecurrenceProperties(event.recurrence);
+}
+
+function attendees(event: CreateEventInput | UpdateEventInput) {
+  if (event.attendees === null) {
+    return [];
+  }
+
+  if (!event.attendees) {
+    return undefined;
+  }
+
+  return toGoogleCalendarAttendees(event.attendees);
+}
+
+function conference(event: CreateEventInput | UpdateEventInput) {
+  if (event.conference === null) {
+    return null;
+  }
+
+  if (!event.conference) {
+    return undefined;
+  }
+
+  return toGoogleCalendarConferenceData(event.conference);
+}
+
 export function toGoogleCalendarEvent(
   event: CreateEventInput | UpdateEventInput,
 ): GoogleCalendarEventCreateParams {
@@ -238,18 +275,14 @@ export function toGoogleCalendarEvent(
             event.availability === "free" ? "transparent" : "opaque",
         }
       : {}),
-    ...(event.attendees
-      ? { attendees: toGoogleCalendarAttendees(event.attendees) }
-      : {}),
+    attendees: attendees(event),
     ...(event.conference
       ? { conferenceData: toGoogleCalendarConferenceData(event.conference) }
       : {}),
     // Should always be 1 to ensure conference data is retained for all event modification requests.
     conferenceDataVersion: 1,
     // TODO: how to handle recurrence when the time zone is changed (i.e. until, rDate, exDate).
-    ...(event.recurrence
-      ? { recurrence: toRecurrenceProperties(event.recurrence) }
-      : {}),
+    recurrence: recurrences(event),
     recurringEventId: event.recurringEventId,
   };
 }

--- a/packages/api/src/providers/calendars/interfaces.ts
+++ b/packages/api/src/providers/calendars/interfaces.ts
@@ -3,6 +3,7 @@ import { Temporal } from "temporal-polyfill";
 import type {
   Calendar,
   CalendarEvent,
+  CalendarEventSyncItem,
   CalendarFreeBusy,
 } from "../../interfaces";
 import type { CreateEventInput, UpdateEventInput } from "../../schemas/events";
@@ -11,6 +12,20 @@ export interface ResponseToEventInput {
   status: "accepted" | "tentative" | "declined" | "unknown";
   comment?: string;
   sendUpdate: boolean;
+}
+
+export interface CalendarProviderSyncOptions {
+  calendar: Calendar;
+  initialSyncToken?: string | undefined;
+  timeMin?: Temporal.ZonedDateTime;
+  timeMax?: Temporal.ZonedDateTime;
+  timeZone: string;
+}
+
+export interface CalendarProviderSyncResult {
+  changes: CalendarEventSyncItem[];
+  syncToken: string | undefined;
+  status: "incremental" | "full";
 }
 
 export interface CalendarProvider {
@@ -33,6 +48,9 @@ export interface CalendarProvider {
     events: CalendarEvent[];
     recurringMasterEvents: CalendarEvent[];
   }>;
+  sync(
+    options: CalendarProviderSyncOptions,
+  ): Promise<CalendarProviderSyncResult>;
   event(
     calendar: Calendar,
     eventId: string,

--- a/packages/api/src/providers/calendars/microsoft-calendar.ts
+++ b/packages/api/src/providers/calendars/microsoft-calendar.ts
@@ -1,7 +1,6 @@
 import { Client } from "@microsoft/microsoft-graph-client";
 import type {
   Calendar as MicrosoftCalendar,
-  Event as MicrosoftEvent,
   ScheduleInformation,
 } from "@microsoft/microsoft-graph-types";
 import { Temporal } from "temporal-polyfill";
@@ -10,6 +9,7 @@ import { CALENDAR_DEFAULTS } from "../../constants/calendar";
 import type {
   Calendar,
   CalendarEvent,
+  CalendarEventSyncItem,
   CalendarFreeBusy,
 } from "../../interfaces";
 import type {
@@ -18,7 +18,11 @@ import type {
 } from "../../schemas/calendars";
 import type { CreateEventInput, UpdateEventInput } from "../../schemas/events";
 import { ProviderError } from "../lib/provider-error";
-import type { CalendarProvider, ResponseToEventInput } from "./interfaces";
+import type {
+  CalendarProvider,
+  CalendarProviderSyncOptions,
+  ResponseToEventInput,
+} from "./interfaces";
 import {
   calendarPath,
   parseMicrosoftCalendar,
@@ -30,6 +34,7 @@ import {
   toMicrosoftEvent,
 } from "./microsoft-calendar/events";
 import { parseScheduleItem } from "./microsoft-calendar/freebusy";
+import type { MicrosoftEvent } from "./microsoft-calendar/interfaces";
 
 interface MicrosoftCalendarProviderOptions {
   accessToken: string;
@@ -132,21 +137,106 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
     });
   }
 
+  async sync({
+    calendar,
+    initialSyncToken,
+    timeMin,
+    timeMax,
+    timeZone,
+  }: CalendarProviderSyncOptions): Promise<{
+    changes: CalendarEventSyncItem[];
+    syncToken: string | undefined;
+    status: "incremental" | "full";
+  }> {
+    return this.withErrorHandler("sync", async () => {
+      const startTime = timeMin?.withTimeZone("UTC").toInstant().toString();
+      const endTime = timeMax?.withTimeZone("UTC").toInstant().toString();
+
+      let syncToken: string | undefined;
+      let pageToken: string | undefined = undefined;
+
+      const baseUrl = new URL(
+        `${calendarPath(calendar.id)}/calendarView/delta`,
+      );
+
+      if (startTime) {
+        baseUrl.searchParams.set("startDateTime", startTime);
+      }
+
+      if (endTime) {
+        baseUrl.searchParams.set("endDateTime", endTime);
+      }
+
+      const changes: CalendarEventSyncItem[] = [];
+
+      do {
+        const url: string = pageToken ?? initialSyncToken ?? baseUrl.toString();
+
+        const response = await this.graphClient
+          .api(url)
+          .header("Prefer", `outlook.timezone="${timeZone}"`)
+          .orderby("start/dateTime")
+          .top(CALENDAR_DEFAULTS.MAX_EVENTS_PER_CALENDAR)
+          .get();
+
+        // if (!initialSyncToken && !pageToken && startTime && endTime) {
+        //   request.filter(
+        //     `start/dateTime ge '${startTime}' and end/dateTime le '${endTime}'`,
+        //   );
+        // }
+
+        for (const item of response.value as MicrosoftEvent[]) {
+          if (!item?.id) {
+            continue;
+          }
+
+          if (item["@removed"]) {
+            changes.push({
+              status: "deleted",
+              event: {
+                id: item.id,
+                calendarId: calendar.id,
+                accountId: this.accountId,
+                providerId: this.providerId,
+                providerAccountId: this.accountId,
+              },
+            });
+
+            continue;
+          }
+
+          changes.push({
+            status: "updated",
+            event: parseMicrosoftEvent({
+              event: item,
+              accountId: this.accountId,
+              calendar,
+            }),
+          });
+        }
+
+        pageToken = response["@odata.nextLink"];
+        syncToken = response["@odata.deltaLink"];
+      } while (pageToken);
+
+      return {
+        changes,
+        syncToken,
+        status: "incremental",
+      };
+    });
+  }
+
   async event(
     calendar: Calendar,
     eventId: string,
-    timeZone?: string,
+    timeZone: string,
   ): Promise<CalendarEvent> {
     return this.withErrorHandler("event", async () => {
-      const request = this.graphClient.api(
-        `${calendarPath(calendar.id)}/events/${eventId}`,
-      );
-
-      if (timeZone) {
-        request.header("Prefer", `outlook.timezone="${timeZone}"`);
-      }
-
-      const event: MicrosoftEvent = await request.get();
+      const event: MicrosoftEvent = await this.graphClient
+        .api(`${calendarPath(calendar.id)}/events/${eventId}`)
+        .header("Prefer", `outlook.timezone="${timeZone}"`)
+        .get();
 
       return parseMicrosoftEvent({
         event,
@@ -246,7 +336,8 @@ export class MicrosoftCalendarProvider implements CalendarProvider {
       // Placeholder: Microsoft Graph does not have a direct move endpoint.
       // This could be implemented by creating a new event in destination and deleting the original,
       // preserving fields as needed.
-      const event = await this.event(sourceCalendar, eventId);
+      const event = await this.event(sourceCalendar, eventId, "UTC");
+
       return {
         ...event,
         calendarId: destinationCalendar.id,

--- a/packages/api/src/providers/calendars/microsoft-calendar/calendars.ts
+++ b/packages/api/src/providers/calendars/microsoft-calendar/calendars.ts
@@ -20,6 +20,7 @@ export function parseMicrosoftCalendar({
     providerAccountId: accountId,
     color: calendar.hexColor!,
     readOnly: !calendar.canEdit,
+    syncToken: null,
   };
 }
 

--- a/packages/api/src/providers/calendars/microsoft-calendar/interfaces.ts
+++ b/packages/api/src/providers/calendars/microsoft-calendar/interfaces.ts
@@ -1,0 +1,9 @@
+import type { Event } from "@microsoft/microsoft-graph-types";
+
+export interface MicrosoftEvent extends Event {
+  "@removed": {
+    reason?: string | undefined;
+  };
+  "@odata.nextLink"?: string | undefined;
+  "@odata.deltaLink"?: string | undefined;
+}

--- a/packages/api/src/routers/calendars.ts
+++ b/packages/api/src/routers/calendars.ts
@@ -11,6 +11,15 @@ import {
 } from "../trpc";
 
 export const calendarsRouter = createTRPCRouter({
+  sync: calendarProcedure.query(async ({ ctx }) => {
+    const promises = ctx.providers.map(async ({ client }) => {
+      return client.calendars();
+    });
+
+    const results = await Promise.all(promises);
+
+    return results.flat();
+  }),
   list: calendarProcedure.query(async ({ ctx }) => {
     const promises = ctx.providers.map(async ({ client, account }) => {
       const calendars = await client.calendars();


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added incremental sync for Google and Microsoft calendars to fetch only changes (updates and deletes) and return a new sync token. This makes event syncing faster and reduces API usage, including support for recurring series.

- **New Features**
  - Added events.sync endpoint (timeMin/timeMax, timeZone, optional syncToken) that returns changes, a new syncToken, and status ("incremental" or "full").
  - Added calendars.sync endpoint to retrieve calendars across providers.
  - Implemented provider-level sync:
    - Google: uses events.list with syncToken, handles 410/fullSyncRequired, and fetches recurring master events for instances.
    - Microsoft: uses calendarView/delta with @odata.nextLink/@odata.deltaLink and deleted markers (@removed).
  - Calendar now includes syncToken; new CalendarEventSyncItem type models updated/deleted changes.
  - Improved event update mapping for attendees, recurrence, and conference to correctly support clearing (null) vs leaving unchanged (undefined).

- **Migration**
  - Store syncToken per calendar and pass it to events.sync on subsequent calls.
  - Handle "deleted" changes by removing events locally; apply "updated" changes to upsert.
  - On status="full", replace local event cache for the requested window.
  - Always supply a timeZone; use timeMin/timeMax when you want to bound the sync window.

<!-- End of auto-generated description by cubic. -->

