### PR TITLE
feat(web): add infinite agenda view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ count.txt
 .vinxi
 __unconfig*
 todos.json
+
+.tmp
+.visual-testing
+.devtools
+.groupedtimelineinclude
+.docs
+.cursor

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-day.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-day.tsx
@@ -9,7 +9,6 @@ import { DisplayItem } from "@/lib/display-item";
 import { cn } from "@/lib/utils";
 import { format } from "@/lib/utils/format";
 import { useDefaultTimeZone } from "@/store/hooks";
-import { displayItemOverlapsDay } from "../utils/positioning/inline-items";
 import { AgendaViewItem } from "./agenda-view-item";
 
 interface AgendaViewDayHeaderProps {
@@ -63,19 +62,11 @@ interface AgendaViewDayProps {
 export function AgendaViewDay({ day, items }: AgendaViewDayProps) {
   "use memo";
 
-  const events = React.useMemo(() => {
-    return items.filter((item) => displayItemOverlapsDay(item, day));
-  }, [day, items]);
-
-  if (events.length === 0) {
-    return null;
-  }
-
   return (
     <AgendaViewDayContainer>
       <AgendaViewDayHeader day={day} />
       <AgendaViewDayContent>
-        {events.map((event) => (
+        {items.map((event) => (
           <AgendaViewItem key={event.id} item={event} />
         ))}
       </AgendaViewDayContent>

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
@@ -61,6 +61,7 @@ export function AgendaViewList() {
     canExtendForward,
     extendBackward,
     extendForward,
+    extendAround,
     resetWindowAround,
   } = useAgendaView();
 
@@ -225,12 +226,8 @@ export function AgendaViewList() {
     }
 
     if (days.length === 0) {
-      if (canExtendForward) {
-        extendForward();
-      }
-
-      if (canExtendBackward) {
-        extendBackward();
+      if (canExtendForward || canExtendBackward) {
+        extendAround();
       }
 
       return;
@@ -263,9 +260,14 @@ export function AgendaViewList() {
           scrollElement.clientHeight * START_RUNWAY_VIEWPORTS);
 
     // One side per pass: at the MAX_CHUNKS cap an extension evicts from the
-    // far side, so firing both would ping-pong extend/evict forever.
+    // far side, so firing both would ping-pong extend/evict forever. When the
+    // preferred backward side is exhausted, fall through to forward — a list
+    // too short to scroll keeps nearStart true with a null scrollDirection
+    // and would otherwise never reach future chunks.
     const forwardFirst =
-      !nearStart || virtualizer.scrollDirection === "forward";
+      !nearStart ||
+      !canExtendBackward ||
+      virtualizer.scrollDirection === "forward";
 
     if (nearEnd && forwardFirst && canExtendForward) {
       extendForward();

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
@@ -18,7 +18,10 @@ const EDGE_DAYS = 14;
 const EDGE_ITEMS = 10;
 // Backward runway floor in viewport-heights: below this much loaded content
 // above the viewport, extend regardless of the day/item-based triggers.
-const START_RUNWAY_VIEWPORTS = 2;
+// Sized for a strong fling: it must cover the distance momentum travels
+// during one uncached chunk round trip, or the fling reaches the top while
+// extension is stalled on the network.
+const START_RUNWAY_VIEWPORTS = 5;
 const SCROLL_SILENCE_MS = 160;
 
 // WebKit drops programmatic scrollTop writes while a momentum gesture is

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
@@ -16,7 +16,19 @@ import { useAgendaView } from "./agenda-view-provider";
 
 const EDGE_DAYS = 14;
 const EDGE_ITEMS = 10;
+// Backward runway floor in viewport-heights: below this much loaded content
+// above the viewport, extend regardless of the day/item-based triggers.
+const START_RUNWAY_VIEWPORTS = 2;
 const SCROLL_SILENCE_MS = 160;
+
+// WebKit drops programmatic scrollTop writes while a momentum gesture is
+// live, so prepend compensation cannot land mid-fling there. Engine-level,
+// not browser-level: iOS Chrome (CriOS) and Firefox (FxiOS) are WebKit too
+// and neither matches the exclusion list.
+const IS_WEBKIT =
+  typeof navigator !== "undefined" &&
+  /AppleWebKit/.test(navigator.userAgent) &&
+  !/Chrome|Chromium|Edg/.test(navigator.userAgent);
 
 function AgendaViewEmpty() {
   "use memo";
@@ -233,8 +245,19 @@ export function AgendaViewList() {
       last.index >= days.length - EDGE_ITEMS ||
       loadedEnd.since(days[last.index]!.date).days <= EDGE_DAYS;
 
+    const scrollElement = scrollRef.current;
+
+    // Three triggers, each covering a density the others miss: item count
+    // (sparse stretches — the day-distance test alone stalls after an empty
+    // prepend, because the gap to loadedStart only ever grows), day distance
+    // (dense top region where EDGE_ITEMS spans too few days), and a pixel
+    // runway floor (few tall day groups where either count is misleading).
     const nearStart =
-      days[first.index]!.date.since(loadedStart).days <= EDGE_DAYS;
+      first.index < EDGE_ITEMS ||
+      days[first.index]!.date.since(loadedStart).days <= EDGE_DAYS ||
+      (scrollElement !== null &&
+        scrollElement.scrollTop <
+          scrollElement.clientHeight * START_RUNWAY_VIEWPORTS);
 
     // One side per pass: at the MAX_CHUNKS cap an extension evicts from the
     // far side, so firing both would ping-pong extend/evict forever.
@@ -244,9 +267,11 @@ export function AgendaViewList() {
     if (nearEnd && forwardFirst && canExtendForward) {
       extendForward();
     } else if (nearStart && canExtendBackward) {
-      // Prepends are deferred while a gesture/momentum is live; applying the
-      // insertion mid-momentum is the scroll write Safari drops.
-      if (isScrollingRef.current) {
+      // On WebKit, prepends are deferred while a gesture/momentum is live;
+      // applying the insertion mid-momentum needs the compensating scrollTop
+      // write that engine drops. Blink and Gecko honor mid-momentum writes,
+      // so they prepend immediately and a fling never reaches the top edge.
+      if (IS_WEBKIT && isScrollingRef.current) {
         pendingPrependRef.current = true;
       } else {
         extendBackward();

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-list.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+// Required to ensure the scroll position is reset on fast refresh
+// @refresh reset
+import * as React from "react";
+// Polyfills the scrollend event; remove once scrollend browser support on caniuse.com reaches 90%
+import "scrollyfills";
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Temporal } from "temporal-polyfill";
+
+import { isInlineItem } from "@/lib/display-item";
+import { useCalendarStore } from "@/providers/calendar-store-provider";
+import { AgendaViewDay } from "./agenda-view-day";
+import { useAgendaView } from "./agenda-view-provider";
+
+const EDGE_DAYS = 14;
+const EDGE_ITEMS = 10;
+const SCROLL_SILENCE_MS = 160;
+
+function AgendaViewEmpty() {
+  "use memo";
+
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center py-16 text-center">
+      <CalendarIcon className="mb-2 text-muted-foreground/50" />
+      <h3 className="text-lg font-medium">No items found</h3>
+      <p className="text-muted-foreground">
+        There are no items scheduled for this time period.
+      </p>
+    </div>
+  );
+}
+
+// No "use memo": the React Compiler cannot observe when
+// virtualizer.getVirtualItems() changes and would over-memoize.
+export function AgendaViewList() {
+  const scrollRef = React.useRef<HTMLDivElement | null>(null);
+
+  const {
+    days,
+    loadedStart,
+    loadedEnd,
+    isPending,
+    canExtendBackward,
+    canExtendForward,
+    extendBackward,
+    extendForward,
+    resetWindowAround,
+  } = useAgendaView();
+
+  const currentDate = useCalendarStore((s) => s.currentDate);
+  const navigationNonce = useCalendarStore((s) => s.navigationNonce);
+  const setCurrentDate = useCalendarStore((s) => s.setCurrentDate);
+
+  const virtualizer = useVirtualizer({
+    count: days.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) =>
+      96 + days[index]!.items.filter(isInlineItem).length * 48,
+    overscan: 5,
+    getItemKey: (index) => days[index]!.key,
+  });
+
+  // Single-writer rule: the core's own size-change adjustments write
+  // scrollTop inside ResizeObserver callbacks, one task before React commits
+  // the matching item positions — each measurement batch paints a frame of
+  // content shifted against the gesture. All compensation happens instead in
+  // the per-commit layout effect below, atomically with the positions it
+  // compensates for.
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => false;
+
+  // Viewport anchor: the topmost visible day group and its content-space
+  // position (DOM rect + scrollTop). Content-space is invariant under
+  // scrolling, so the compensation delta is exactly how far layout changes
+  // moved the anchor — user scrolling between capture and commit cancels out.
+  const anchorRef = React.useRef<{ key: string; contentPos: number } | null>(
+    null,
+  );
+  const lastSyncedDayRef = React.useRef<string | null>(null);
+  const pendingTargetRef = React.useRef<Temporal.PlainDate | null>(null);
+  const isScrollingRef = React.useRef(false);
+  const pendingPrependRef = React.useRef(false);
+
+  const keyIndex = React.useMemo(
+    () => new Map(days.map((day, index) => [day.key, index])),
+    [days],
+  );
+
+  // Content-space position of a day group, read from the DOM when its
+  // element is mounted (the painted truth — the virtualizer's measurement
+  // cache can run ahead of the DOM between commits), from the virtualizer's
+  // layout otherwise (identical to the committed DOM within one commit).
+  const anchorContentPos = React.useEffectEvent(
+    (scrollElement: HTMLDivElement, key: string) => {
+      const element = virtualizer.elementsCache.get(key);
+
+      if (element) {
+        return (
+          element.getBoundingClientRect().top -
+          scrollElement.getBoundingClientRect().top +
+          scrollElement.scrollTop
+        );
+      }
+
+      const index = keyIndex.get(key);
+
+      if (index === undefined) {
+        return undefined;
+      }
+
+      const offset = virtualizer.getOffsetForIndex(index, "start");
+
+      if (!offset) {
+        return undefined;
+      }
+
+      return offset[0];
+    },
+  );
+
+  const updateAnchor = React.useEffectEvent(() => {
+    const scrollElement = scrollRef.current;
+
+    if (!scrollElement) {
+      return;
+    }
+
+    const item = virtualizer.getVirtualItemForOffset(scrollElement.scrollTop);
+
+    if (!item) {
+      anchorRef.current = null;
+      return;
+    }
+
+    const key = String(item.key);
+    const contentPos = anchorContentPos(scrollElement, key);
+
+    if (contentPos === undefined) {
+      anchorRef.current = null;
+      return;
+    }
+
+    anchorRef.current = { key, contentPos };
+  });
+
+  const compensate = React.useEffectEvent(() => {
+    const scrollElement = scrollRef.current;
+    const anchor = anchorRef.current;
+
+    if (!scrollElement || !anchor) {
+      return;
+    }
+
+    const contentPos = anchorContentPos(scrollElement, anchor.key);
+
+    if (contentPos === undefined) {
+      // The anchored day group no longer exists; re-anchor to whatever is at
+      // the current offset so later commits stay compensated.
+      updateAnchor();
+      return;
+    }
+
+    const delta = contentPos - anchor.contentPos;
+
+    // Sub-pixel deltas are skipped without rebaselining so they accumulate
+    // until correctable instead of drifting.
+    if (Math.abs(delta) < 1) {
+      return;
+    }
+
+    scrollElement.scrollTop += delta;
+    anchor.contentPos = contentPos;
+  });
+
+  // Compensation runs in every commit, before paint: any commit may move the
+  // anchored day group (prepended/evicted day groups above it, or
+  // estimate→measured corrections of groups above it) and the scrollTop
+  // write must land atomically with the item positions it compensates for.
+  React.useLayoutEffect(() => {
+    compensate();
+  });
+
+  const syncFromScroll = React.useEffectEvent(() => {
+    const scrollElement = scrollRef.current;
+
+    if (!scrollElement || pendingTargetRef.current) {
+      return;
+    }
+
+    const item = virtualizer.getVirtualItemForOffset(scrollElement.scrollTop);
+
+    if (!item) {
+      return;
+    }
+
+    const day = days[item.index];
+
+    if (!day || lastSyncedDayRef.current === day.key) {
+      return;
+    }
+
+    lastSyncedDayRef.current = day.key;
+    setCurrentDate(day.date, { keepTimeRange: true });
+  });
+
+  const checkEdges = React.useEffectEvent(() => {
+    if (pendingTargetRef.current || isPending) {
+      return;
+    }
+
+    if (days.length === 0) {
+      if (canExtendForward) {
+        extendForward();
+      }
+
+      if (canExtendBackward) {
+        extendBackward();
+      }
+
+      return;
+    }
+
+    const virtualItems = virtualizer.getVirtualItems();
+    const first = virtualItems[0];
+    const last = virtualItems.at(-1);
+
+    if (!first || !last) {
+      return;
+    }
+
+    const nearEnd =
+      last.index >= days.length - EDGE_ITEMS ||
+      loadedEnd.since(days[last.index]!.date).days <= EDGE_DAYS;
+
+    const nearStart =
+      days[first.index]!.date.since(loadedStart).days <= EDGE_DAYS;
+
+    // One side per pass: at the MAX_CHUNKS cap an extension evicts from the
+    // far side, so firing both would ping-pong extend/evict forever.
+    const forwardFirst =
+      !nearStart || virtualizer.scrollDirection === "forward";
+
+    if (nearEnd && forwardFirst && canExtendForward) {
+      extendForward();
+    } else if (nearStart && canExtendBackward) {
+      // Prepends are deferred while a gesture/momentum is live; applying the
+      // insertion mid-momentum is the scroll write Safari drops.
+      if (isScrollingRef.current) {
+        pendingPrependRef.current = true;
+      } else {
+        extendBackward();
+      }
+    }
+  });
+
+  const flushDeferredPrepend = React.useEffectEvent(() => {
+    isScrollingRef.current = false;
+
+    if (!pendingPrependRef.current) {
+      return;
+    }
+
+    pendingPrependRef.current = false;
+
+    if (!isPending && canExtendBackward) {
+      extendBackward();
+    }
+  });
+
+  React.useEffect(() => {
+    const scrollElement = scrollRef.current;
+
+    if (!scrollElement) {
+      return;
+    }
+
+    let frame: number | null = null;
+    let silenceTimer: number | null = null;
+
+    const onScroll = () => {
+      updateAnchor();
+      isScrollingRef.current = true;
+
+      if (silenceTimer !== null) {
+        window.clearTimeout(silenceTimer);
+      }
+
+      silenceTimer = window.setTimeout(() => {
+        silenceTimer = null;
+        flushDeferredPrepend();
+      }, SCROLL_SILENCE_MS);
+
+      if (frame !== null) {
+        return;
+      }
+
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        syncFromScroll();
+        checkEdges();
+      });
+    };
+
+    const onScrollEnd = () => {
+      if (silenceTimer !== null) {
+        window.clearTimeout(silenceTimer);
+        silenceTimer = null;
+      }
+
+      flushDeferredPrepend();
+    };
+
+    const controller = new AbortController();
+
+    scrollElement.addEventListener("scroll", onScroll, {
+      passive: true,
+      signal: controller.signal,
+    });
+
+    scrollElement.addEventListener("scrollend", onScrollEnd, {
+      signal: controller.signal,
+    });
+
+    return () => {
+      controller.abort();
+
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+
+      if (silenceTimer !== null) {
+        window.clearTimeout(silenceTimer);
+      }
+    };
+  }, []);
+
+  const correctPendingScroll = React.useEffectEvent(
+    (target: Temporal.PlainDate) => {
+      // Re-derived from the target date: a prepend landing between the first
+      // scrollToIndex and this correction shifts every index.
+      const index = days.findIndex(
+        (day) => Temporal.PlainDate.compare(day.date, target) >= 0,
+      );
+
+      if (index === -1) {
+        return;
+      }
+
+      virtualizer.scrollToIndex(index, { align: "start" });
+      updateAnchor();
+    },
+  );
+
+  const attemptPendingScroll = React.useEffectEvent(() => {
+    const target = pendingTargetRef.current;
+
+    if (!target || isPending) {
+      return;
+    }
+
+    const index = days.findIndex(
+      (day) => Temporal.PlainDate.compare(day.date, target) >= 0,
+    );
+
+    if (index === -1) {
+      // Empty target stretch: keep extending forward until a day group
+      // appears or the auto-extension cap is reached.
+      if (canExtendForward) {
+        extendForward();
+        return;
+      }
+
+      pendingTargetRef.current = null;
+      updateAnchor();
+      return;
+    }
+
+    pendingTargetRef.current = null;
+    virtualizer.scrollToIndex(index, { align: "start" });
+    updateAnchor();
+
+    requestAnimationFrame(() => {
+      // One post-layout correction pass: the first scroll lands on estimates.
+      correctPendingScroll(target);
+    });
+  });
+
+  React.useLayoutEffect(() => {
+    attemptPendingScroll();
+  });
+
+  const navigate = React.useEffectEvent(() => {
+    pendingTargetRef.current = currentDate;
+    lastSyncedDayRef.current = null;
+
+    if (
+      Temporal.PlainDate.compare(currentDate, loadedStart) < 0 ||
+      Temporal.PlainDate.compare(currentDate, loadedEnd) > 0
+    ) {
+      resetWindowAround(currentDate);
+      return;
+    }
+
+    attemptPendingScroll();
+  });
+
+  // Keyed on navigationNonce only; currentDate is read imperatively so
+  // scroll-driven currentDate writes don't re-trigger navigation.
+  React.useLayoutEffect(() => {
+    navigate();
+  }, [navigationNonce]);
+
+  React.useEffect(() => {
+    checkEdges();
+  }, [days, isPending]);
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  // overflow-anchor: none — the manual compensation above is the only active
+  // compensation path; Chrome's native scroll anchoring would double-shift
+  // and Safari has no overflow-anchor at all.
+  return (
+    <div
+      ref={scrollRef}
+      data-slot="agenda-view"
+      className="relative scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-4 [overflow-anchor:none]"
+    >
+      <div
+        className="relative border-t border-border/70"
+        style={{ height: virtualizer.getTotalSize() }}
+      >
+        {virtualItems.map((item) => {
+          const day = days[item.index];
+
+          if (!day) {
+            return null;
+          }
+
+          return (
+            <div
+              key={item.key}
+              data-index={item.index}
+              ref={virtualizer.measureElement}
+              className="absolute top-0 left-0 w-full"
+              style={{ transform: `translateY(${item.start}px)` }}
+            >
+              <AgendaViewDay day={day.date} items={day.items} />
+            </div>
+          );
+        })}
+      </div>
+      {days.length === 0 && !isPending ? <AgendaViewEmpty /> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
@@ -18,6 +18,11 @@ const MAX_CHUNKS = 12;
 // Auto-extension through empty stretches stops once the window edge is more
 // than ~1 year past the nearest loaded event (or the window anchor).
 const AUTO_EXTEND_LIMIT_DAYS = 370;
+// Chunks kept warm beyond each extendable edge. Depth 1 is not enough: a
+// fling consumes the warm chunk instantly, and extension then stalls a full
+// round trip. At depth 2 the chunk behind the one being consumed is already
+// in flight.
+const PREFETCH_CHUNKS = 2;
 
 const EPOCH = Temporal.PlainDate.from("1970-01-01");
 
@@ -191,28 +196,33 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
   const canExtendForward =
     loadedEnd.since(lastLoadedDay).days < AUTO_EXTEND_LIMIT_DAYS;
 
-  // Keep the next chunk on each extendable side warm so an extension mounts
-  // as a cache hit instead of holding the user at the window edge for a
-  // network round trip. Deferred until the visible window has loaded so the
-  // prefetch never competes with queries the user is waiting on.
+  // Keep the next chunks on each extendable side warm so extensions mount as
+  // cache hits instead of holding the user at the window edge for a network
+  // round trip. Skipped only during a cold load (mount/teleport), when the
+  // user is waiting on the visible window itself — a pending chunk at one
+  // edge must NOT pause prefetching, or the pipeline dries up exactly while
+  // a fling is draining the runway.
   React.useEffect(() => {
-    if (isPending) {
+    if (isPending && days.length === 0) {
       return;
     }
 
-    if (canExtendBackward) {
-      void queryClient.prefetchQuery(
-        trpc.events.list.queryOptions(chunkInput(range.start - 1)),
-      );
-    }
+    for (let depth = 1; depth <= PREFETCH_CHUNKS; depth++) {
+      if (canExtendBackward) {
+        void queryClient.prefetchQuery(
+          trpc.events.list.queryOptions(chunkInput(range.start - depth)),
+        );
+      }
 
-    if (canExtendForward) {
-      void queryClient.prefetchQuery(
-        trpc.events.list.queryOptions(chunkInput(range.end + 1)),
-      );
+      if (canExtendForward) {
+        void queryClient.prefetchQuery(
+          trpc.events.list.queryOptions(chunkInput(range.end + depth)),
+        );
+      }
     }
   }, [
     isPending,
+    days.length,
     canExtendBackward,
     canExtendForward,
     range,

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import * as React from "react";
+import { useQueries } from "@tanstack/react-query";
+import { Temporal } from "temporal-polyfill";
+
+import { useProcessedDisplayItems } from "@/hooks/calendar/use-display-items";
+import { useSelectDisplayItems } from "@/hooks/calendar/use-events";
+import type { DisplayItem } from "@/lib/display-item";
+import { useTRPC } from "@/lib/trpc/client";
+import { CalendarStoreContext } from "@/providers/calendar-store-provider";
+import { useDefaultTimeZone } from "@/store/hooks";
+
+const CHUNK_DAYS = 60;
+// Retention: at most ~2 years of chunks are kept; extending past the cap
+// evicts from the far side.
+const MAX_CHUNKS = 12;
+// Auto-extension through empty stretches stops once the window edge is more
+// than ~1 year past the nearest loaded event (or the window anchor).
+const AUTO_EXTEND_LIMIT_DAYS = 370;
+
+const EPOCH = Temporal.PlainDate.from("1970-01-01");
+
+function chunkIndexOf(date: Temporal.PlainDate) {
+  return Math.floor(date.since(EPOCH).days / CHUNK_DAYS);
+}
+
+function chunkStart(index: number) {
+  return EPOCH.add({ days: index * CHUNK_DAYS });
+}
+
+interface ChunkRange {
+  start: number;
+  end: number;
+}
+
+function chunkRangeAround(date: Temporal.PlainDate): ChunkRange {
+  return {
+    start: chunkIndexOf(date.subtract({ days: CHUNK_DAYS })),
+    end: chunkIndexOf(date.add({ days: CHUNK_DAYS })),
+  };
+}
+
+function laterDate(a: Temporal.PlainDate, b: Temporal.PlainDate) {
+  return Temporal.PlainDate.compare(a, b) >= 0 ? a : b;
+}
+
+function earlierDate(a: Temporal.PlainDate, b: Temporal.PlainDate) {
+  return Temporal.PlainDate.compare(a, b) <= 0 ? a : b;
+}
+
+export interface AgendaViewDayGroup {
+  key: string;
+  date: Temporal.PlainDate;
+  items: DisplayItem[];
+}
+
+interface AgendaViewContextValue {
+  days: AgendaViewDayGroup[];
+  loadedStart: Temporal.PlainDate;
+  loadedEnd: Temporal.PlainDate;
+  isPending: boolean;
+  canExtendBackward: boolean;
+  canExtendForward: boolean;
+  extendBackward: () => void;
+  extendForward: () => void;
+  resetWindowAround: (date: Temporal.PlainDate) => void;
+}
+
+const AgendaViewContext = React.createContext<AgendaViewContextValue | null>(
+  null,
+);
+AgendaViewContext.displayName = "AgendaViewContext";
+
+interface AgendaViewProviderProps {
+  children: React.ReactNode;
+}
+
+export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
+  "use memo";
+
+  const store = React.use(CalendarStoreContext);
+
+  if (!store) {
+    throw new Error(
+      "AgendaViewProvider must be used within CalendarStoreProvider",
+    );
+  }
+
+  // The window is initialized from mount-time currentDate only; afterwards it
+  // moves exclusively through extension and teleport resets.
+  const [anchorDate, setAnchorDate] = React.useState(
+    () => store.getState().currentDate,
+  );
+  const [range, setRange] = React.useState(() => chunkRangeAround(anchorDate));
+
+  const trpc = useTRPC();
+  const defaultTimeZone = useDefaultTimeZone();
+  const select = useSelectDisplayItems();
+
+  const chunkIndices = React.useMemo(
+    () =>
+      Array.from(
+        { length: range.end - range.start + 1 },
+        (_, offset) => range.start + offset,
+      ),
+    [range],
+  );
+
+  const { items: chunkItems, isPending } = useQueries({
+    queries: chunkIndices.map((index) =>
+      trpc.events.list.queryOptions(
+        {
+          timeMin: chunkStart(index).toZonedDateTime({
+            timeZone: defaultTimeZone,
+          }),
+          timeMax: chunkStart(index + 1).toZonedDateTime({
+            timeZone: defaultTimeZone,
+          }),
+          defaultTimeZone,
+        },
+        { select },
+      ),
+    ),
+    combine: (results) => ({
+      items: results.flatMap((result) => result.data ?? []),
+      isPending: results.some((result) => result.isPending),
+    }),
+  });
+
+  const items = React.useMemo(() => {
+    // Adjacent chunk queries can both return an item spanning their boundary.
+    const seen = new Set<string>();
+    const deduped: DisplayItem[] = [];
+
+    for (const item of chunkItems) {
+      if (seen.has(item.id)) {
+        continue;
+      }
+
+      seen.add(item.id);
+      deduped.push(item);
+    }
+
+    return deduped;
+  }, [chunkItems]);
+
+  const processedItems = useProcessedDisplayItems(items);
+
+  const loadedStart = chunkStart(range.start);
+  const loadedEnd = chunkStart(range.end + 1).subtract({ days: 1 });
+
+  const days = React.useMemo(() => {
+    const buckets = new Map<string, DisplayItem[]>();
+
+    for (const item of processedItems) {
+      let day = laterDate(item.date.start, loadedStart);
+      const end = earlierDate(item.date.end, loadedEnd);
+
+      while (Temporal.PlainDate.compare(day, end) <= 0) {
+        const key = day.toString();
+        const bucket = buckets.get(key);
+
+        if (bucket) {
+          bucket.push(item);
+        } else {
+          buckets.set(key, [item]);
+        }
+
+        day = day.add({ days: 1 });
+      }
+    }
+
+    return [...buckets.keys()].sort().map((key) => ({
+      key,
+      date: Temporal.PlainDate.from(key),
+      items: buckets.get(key)!,
+    }));
+  }, [processedItems, loadedStart, loadedEnd]);
+
+  const firstLoadedDay = days[0]?.date ?? anchorDate;
+  const lastLoadedDay = days.at(-1)?.date ?? anchorDate;
+
+  const canExtendBackward =
+    firstLoadedDay.since(loadedStart).days < AUTO_EXTEND_LIMIT_DAYS;
+  const canExtendForward =
+    loadedEnd.since(lastLoadedDay).days < AUTO_EXTEND_LIMIT_DAYS;
+
+  const extendBackward = React.useCallback(() => {
+    setRange((prev) => ({
+      start: prev.start - 1,
+      end: prev.end - prev.start >= MAX_CHUNKS - 1 ? prev.end - 1 : prev.end,
+    }));
+  }, []);
+
+  const extendForward = React.useCallback(() => {
+    setRange((prev) => ({
+      start:
+        prev.end - prev.start >= MAX_CHUNKS - 1 ? prev.start + 1 : prev.start,
+      end: prev.end + 1,
+    }));
+  }, []);
+
+  const resetWindowAround = React.useCallback((date: Temporal.PlainDate) => {
+    setAnchorDate(date);
+    setRange(chunkRangeAround(date));
+  }, []);
+
+  const value = {
+    days,
+    loadedStart,
+    loadedEnd,
+    isPending,
+    canExtendBackward,
+    canExtendForward,
+    extendBackward,
+    extendForward,
+    resetWindowAround,
+  };
+
+  return <AgendaViewContext value={value}>{children}</AgendaViewContext>;
+}
+
+export function useAgendaView() {
+  const context = React.use(AgendaViewContext);
+
+  if (!context) {
+    throw new Error("useAgendaView must be used within an AgendaViewProvider");
+  }
+
+  return context;
+}

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
@@ -183,8 +183,15 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
     db.events.bulkPut(
       items.filter(isEvent).map((item) => mapEventQueryInput(item.event)),
     );
+
+    // Every chunk overlapping a recurring series returns that series' master,
+    // so dedupe by id before writing.
+    const masters = new Map(
+      recurringMasterEvents.map((event) => [event.id, event]),
+    );
+
     db.events.bulkPut(
-      recurringMasterEvents.map((event) => mapEventQueryInput(event)),
+      [...masters.values()].map((event) => mapEventQueryInput(event)),
     );
   }, [items, recurringMasterEvents]);
 

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { Temporal } from "temporal-polyfill";
 
 import { useProcessedDisplayItems } from "@/hooks/calendar/use-display-items";
@@ -95,6 +95,7 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
   const [range, setRange] = React.useState(() => chunkRangeAround(anchorDate));
 
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const defaultTimeZone = useDefaultTimeZone();
   const select = useSelectDisplayItems();
 
@@ -107,20 +108,24 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
     [range],
   );
 
+  // Single source for the chunk query input: prefetched keys must match the
+  // keys useQueries mounts, or the prefetch warms nothing.
+  const chunkInput = React.useCallback(
+    (index: number) => ({
+      timeMin: chunkStart(index).toZonedDateTime({
+        timeZone: defaultTimeZone,
+      }),
+      timeMax: chunkStart(index + 1).toZonedDateTime({
+        timeZone: defaultTimeZone,
+      }),
+      defaultTimeZone,
+    }),
+    [defaultTimeZone],
+  );
+
   const { items: chunkItems, isPending } = useQueries({
     queries: chunkIndices.map((index) =>
-      trpc.events.list.queryOptions(
-        {
-          timeMin: chunkStart(index).toZonedDateTime({
-            timeZone: defaultTimeZone,
-          }),
-          timeMax: chunkStart(index + 1).toZonedDateTime({
-            timeZone: defaultTimeZone,
-          }),
-          defaultTimeZone,
-        },
-        { select },
-      ),
+      trpc.events.list.queryOptions(chunkInput(index), { select }),
     ),
     combine: (results) => ({
       items: results.flatMap((result) => result.data ?? []),
@@ -185,6 +190,36 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
     firstLoadedDay.since(loadedStart).days < AUTO_EXTEND_LIMIT_DAYS;
   const canExtendForward =
     loadedEnd.since(lastLoadedDay).days < AUTO_EXTEND_LIMIT_DAYS;
+
+  // Keep the next chunk on each extendable side warm so an extension mounts
+  // as a cache hit instead of holding the user at the window edge for a
+  // network round trip. Deferred until the visible window has loaded so the
+  // prefetch never competes with queries the user is waiting on.
+  React.useEffect(() => {
+    if (isPending) {
+      return;
+    }
+
+    if (canExtendBackward) {
+      void queryClient.prefetchQuery(
+        trpc.events.list.queryOptions(chunkInput(range.start - 1)),
+      );
+    }
+
+    if (canExtendForward) {
+      void queryClient.prefetchQuery(
+        trpc.events.list.queryOptions(chunkInput(range.end + 1)),
+      );
+    }
+  }, [
+    isPending,
+    canExtendBackward,
+    canExtendForward,
+    range,
+    queryClient,
+    trpc,
+    chunkInput,
+  ]);
 
   const extendBackward = React.useCallback(() => {
     setRange((prev) => ({

--- a/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view-provider.tsx
@@ -6,7 +6,9 @@ import { Temporal } from "temporal-polyfill";
 
 import { useProcessedDisplayItems } from "@/hooks/calendar/use-display-items";
 import { useSelectDisplayItems } from "@/hooks/calendar/use-events";
-import type { DisplayItem } from "@/lib/display-item";
+import { db, mapEventQueryInput } from "@/lib/db";
+import { isEvent, type DisplayItem } from "@/lib/display-item";
+import type { RouterOutputs } from "@/lib/trpc";
 import { useTRPC } from "@/lib/trpc/client";
 import { CalendarStoreContext } from "@/providers/calendar-store-provider";
 import { useDefaultTimeZone } from "@/store/hooks";
@@ -69,6 +71,7 @@ interface AgendaViewContextValue {
   canExtendForward: boolean;
   extendBackward: () => void;
   extendForward: () => void;
+  extendAround: () => void;
   resetWindowAround: (date: Temporal.PlainDate) => void;
 }
 
@@ -102,7 +105,17 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const defaultTimeZone = useDefaultTimeZone();
-  const select = useSelectDisplayItems();
+  const selectDisplayItems = useSelectDisplayItems();
+
+  // Recurring masters ride along for Dexie persistence below; the shared
+  // select would drop them.
+  const select = React.useCallback(
+    (data: RouterOutputs["events"]["list"]) => ({
+      items: selectDisplayItems(data),
+      recurringMasterEvents: data.recurringMasterEvents,
+    }),
+    [selectDisplayItems],
+  );
 
   const chunkIndices = React.useMemo(
     () =>
@@ -128,12 +141,19 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
     [defaultTimeZone],
   );
 
-  const { items: chunkItems, isPending } = useQueries({
+  const {
+    items: chunkItems,
+    recurringMasterEvents,
+    isPending,
+  } = useQueries({
     queries: chunkIndices.map((index) =>
       trpc.events.list.queryOptions(chunkInput(index), { select }),
     ),
     combine: (results) => ({
-      items: results.flatMap((result) => result.data ?? []),
+      items: results.flatMap((result) => result.data?.items ?? []),
+      recurringMasterEvents: results.flatMap((result) =>
+        Object.values(result.data?.recurringMasterEvents ?? {}),
+      ),
       isPending: results.some((result) => result.isPending),
     }),
   });
@@ -154,6 +174,19 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
 
     return deduped;
   }, [chunkItems]);
+
+  // Mirror of the global-query persistence in calendar-view: update/delete
+  // flows and the event form resolve events through Dexie (getEventById), so
+  // events that only exist in agenda chunks — beyond the shared
+  // timeMin/timeMax window — must be persisted too or those flows abort.
+  React.useEffect(() => {
+    db.events.bulkPut(
+      items.filter(isEvent).map((item) => mapEventQueryInput(item.event)),
+    );
+    db.events.bulkPut(
+      recurringMasterEvents.map((event) => mapEventQueryInput(event)),
+    );
+  }, [items, recurringMasterEvents]);
 
   const processedItems = useProcessedDisplayItems(items);
 
@@ -246,6 +279,26 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
     }));
   }, []);
 
+  // Symmetric growth for the empty-window search. Calling extendBackward and
+  // extendForward separately is NOT equivalent: at the MAX_CHUNKS cap each
+  // evicts the opposite edge, so the pair recreates identical bounds as a new
+  // object every pass and churns renders forever. Bailing with `prev` lets
+  // React skip the update entirely.
+  const extendAround = React.useCallback(() => {
+    setRange((prev) => {
+      const size = prev.end - prev.start + 1;
+
+      if (size >= MAX_CHUNKS) {
+        return prev;
+      }
+
+      return {
+        start: prev.start - 1,
+        end: size + 1 >= MAX_CHUNKS ? prev.end : prev.end + 1,
+      };
+    });
+  }, []);
+
   const resetWindowAround = React.useCallback((date: Temporal.PlainDate) => {
     setAnchorDate(date);
     setRange(chunkRangeAround(date));
@@ -260,6 +313,7 @@ export function AgendaViewProvider({ children }: AgendaViewProviderProps) {
     canExtendForward,
     extendBackward,
     extendForward,
+    extendAround,
     resetWindowAround,
   };
 

--- a/apps/web/src/components/calendar/agenda-view/agenda-view.tsx
+++ b/apps/web/src/components/calendar/agenda-view/agenda-view.tsx
@@ -1,53 +1,14 @@
 "use client";
 
-import * as React from "react";
-import { CalendarIcon } from "@heroicons/react/24/outline";
+import { AgendaViewList } from "./agenda-view-list";
+import { AgendaViewProvider } from "./agenda-view-provider";
 
-import type { DisplayItem } from "@/lib/display-item";
-import { useCalendarStore } from "@/providers/calendar-store-provider";
-import { AgendaViewDay } from "./agenda-view-day";
-
-function AgendaViewEmpty() {
+export function AgendaView() {
   "use memo";
 
   return (
-    <div className="absolute inset-0 hidden flex-col items-center justify-center py-16 text-center only:flex">
-      <CalendarIcon className="mb-2 text-muted-foreground/50" />
-      <h3 className="text-lg font-medium">No items found</h3>
-      <p className="text-muted-foreground">
-        There are no items scheduled for this time period.
-      </p>
-    </div>
+    <AgendaViewProvider>
+      <AgendaViewList />
+    </AgendaViewProvider>
   );
-}
-
-interface AgendaViewProps {
-  items: DisplayItem[];
-}
-
-export function AgendaView({ items }: AgendaViewProps) {
-  "use memo";
-
-  const currentDate = useCalendarStore((s) => s.currentDate);
-
-  const days = React.useMemo(() => {
-    return Array.from({ length: 30 }, (_, i) => currentDate.add({ days: i }));
-  }, [currentDate]);
-
-  return (
-    <AgendaViewDayContainer>
-      <AgendaViewEmpty />
-      {days.map((day) => (
-        <AgendaViewDay key={day.toString()} day={day} items={items} />
-      ))}
-    </AgendaViewDayContainer>
-  );
-}
-
-interface AgendaViewDayContainerProps {
-  children: React.ReactNode;
-}
-
-function AgendaViewDayContainer({ children }: AgendaViewDayContainerProps) {
-  return <div className="border-t border-border/70 px-4">{children}</div>;
 }

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -42,25 +42,44 @@ function useDisplayItems() {
   return useProcessedDisplayItems(items);
 }
 
+// The agenda view fetches, processes, and persists its own chunked window,
+// so the shared-range pipeline only mounts for the grid views — keeping
+// useDisplayItems in the parent would run an unused duplicate query while
+// the agenda is active.
 function CalendarViewContent() {
   "use memo";
 
   const view = useCalendarStore((s) => s.calendarView);
-  const items = useDisplayItems();
 
   if (view === "agenda") {
     return <AgendaView />;
   }
 
   if (view === "month") {
-    return (
-      <InfiniteMonthViewProvider items={items}>
-        <InfiniteMonthViewWeekProvider>
-          <InfiniteMonthView />
-        </InfiniteMonthViewWeekProvider>
-      </InfiniteMonthViewProvider>
-    );
+    return <MonthViewContent />;
   }
+
+  return <WeekViewContent />;
+}
+
+function MonthViewContent() {
+  "use memo";
+
+  const items = useDisplayItems();
+
+  return (
+    <InfiniteMonthViewProvider items={items}>
+      <InfiniteMonthViewWeekProvider>
+        <InfiniteMonthView />
+      </InfiniteMonthViewWeekProvider>
+    </InfiniteMonthViewProvider>
+  );
+}
+
+function WeekViewContent() {
+  "use memo";
+
+  const items = useDisplayItems();
 
   return (
     <InfiniteWeekViewProvider items={items}>

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -1,25 +1,19 @@
 "use client";
 
 import * as React from "react";
-import { useAtomValue } from "jotai";
-import { Temporal } from "temporal-polyfill";
-
-import { isAfter } from "@repo/temporal";
 
 import { AgendaView } from "@/components/calendar/agenda-view/agenda-view";
 import { EVENT_GAP, EVENT_HEIGHT } from "@/components/calendar/constants";
 import { MemoizedCalendarHeader } from "@/components/calendar/header/calendar-header";
 import { InfiniteWeekViewDayProvider } from "@/components/calendar/week-view/infinite-week-view-day-provider";
 import { InfiniteWeekViewProvider } from "@/components/calendar/week-view/infinite-week-view-provider";
-import { applyOptimisticActions } from "@/hooks/calendar/apply-optimistic-actions";
-import { optimisticActionsByEventIdAtom } from "@/hooks/calendar/optimistic-actions";
+import { useProcessedDisplayItems } from "@/hooks/calendar/use-display-items";
 import { useEventsForDisplay } from "@/hooks/calendar/use-events";
 import { db, mapEventQueryInput } from "@/lib/db";
 import { isEvent } from "@/lib/display-item";
 import { cn } from "@/lib/utils";
 import { useCalendarStore } from "@/providers/calendar-store-provider";
-import { getCalendarPreference } from "@/store/calendar-store";
-import { useCellHeight, useDefaultTimeZone } from "@/store/hooks";
+import { useCellHeight } from "@/store/hooks";
 import { InfiniteMonthView } from "./month-view/infinite-month-view";
 import { InfiniteMonthViewProvider } from "./month-view/infinite-month-view-provider";
 import { InfiniteMonthViewWeekProvider } from "./month-view/infinite-month-view-week-provider";
@@ -29,14 +23,6 @@ function useDisplayItems() {
   "use memo";
 
   const { data } = useEventsForDisplay();
-
-  const defaultTimeZone = useDefaultTimeZone();
-  const optimisticActions = useAtomValue(optimisticActionsByEventIdAtom);
-
-  const showPastEvents = useCalendarStore(
-    (s) => s.viewPreferences.showPastEvents,
-  );
-  const calendarPreferences = useCalendarStore((s) => s.calendarPreferences);
 
   React.useEffect(() => {
     db.events.bulkPut(
@@ -51,39 +37,9 @@ function useDisplayItems() {
     );
   }, [data?.events, data?.recurringMasterEvents]);
 
-  return React.useMemo(() => {
-    const eventItems = applyOptimisticActions({
-      items: data?.events ?? [],
-      timeZone: defaultTimeZone,
-      optimisticActions,
-    });
+  const items = React.useMemo(() => data?.events ?? [], [data?.events]);
 
-    const now = Temporal.Now.zonedDateTimeISO(defaultTimeZone);
-
-    const pastFiltered = showPastEvents
-      ? eventItems
-      : eventItems.filter((item) => isAfter(item.end, now));
-
-    return pastFiltered.filter((item) => {
-      if (!isEvent(item)) {
-        return true;
-      }
-
-      const preference = getCalendarPreference(
-        calendarPreferences,
-        item.event.calendar.provider.accountId,
-        item.event.calendar.id,
-      );
-
-      return !(preference?.hidden === true);
-    });
-  }, [
-    data?.events,
-    defaultTimeZone,
-    optimisticActions,
-    showPastEvents,
-    calendarPreferences,
-  ]);
+  return useProcessedDisplayItems(items);
 }
 
 function CalendarViewContent() {
@@ -93,7 +49,7 @@ function CalendarViewContent() {
   const items = useDisplayItems();
 
   if (view === "agenda") {
-    return <AgendaView items={items} />;
+    return <AgendaView />;
   }
 
   if (view === "month") {

--- a/apps/web/src/hooks/calendar/use-display-items.ts
+++ b/apps/web/src/hooks/calendar/use-display-items.ts
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { useAtomValue } from "jotai";
+import { Temporal } from "temporal-polyfill";
+
+import { isAfter } from "@repo/temporal";
+
+import { applyOptimisticActions } from "@/hooks/calendar/apply-optimistic-actions";
+import { optimisticActionsByEventIdAtom } from "@/hooks/calendar/optimistic-actions";
+import { DisplayItem, isEvent } from "@/lib/display-item";
+import { useCalendarStore } from "@/providers/calendar-store-provider";
+import { getCalendarPreference } from "@/store/calendar-store";
+import { useDefaultTimeZone } from "@/store/hooks";
+
+export function useProcessedDisplayItems(items: DisplayItem[]) {
+  "use memo";
+
+  const defaultTimeZone = useDefaultTimeZone();
+  const optimisticActions = useAtomValue(optimisticActionsByEventIdAtom);
+
+  const showPastEvents = useCalendarStore(
+    (s) => s.viewPreferences.showPastEvents,
+  );
+  const calendarPreferences = useCalendarStore((s) => s.calendarPreferences);
+
+  return React.useMemo(() => {
+    const eventItems = applyOptimisticActions({
+      items,
+      timeZone: defaultTimeZone,
+      optimisticActions,
+    });
+
+    const now = Temporal.Now.zonedDateTimeISO(defaultTimeZone);
+
+    const pastFiltered = showPastEvents
+      ? eventItems
+      : eventItems.filter((item) => isAfter(item.end, now));
+
+    return pastFiltered.filter((item) => {
+      if (!isEvent(item)) {
+        return true;
+      }
+
+      const preference = getCalendarPreference(
+        calendarPreferences,
+        item.event.calendar.provider.accountId,
+        item.event.calendar.id,
+      );
+
+      return !(preference?.hidden === true);
+    });
+  }, [
+    items,
+    defaultTimeZone,
+    optimisticActions,
+    showPastEvents,
+    calendarPreferences,
+  ]);
+}

--- a/apps/web/src/hooks/calendar/use-event-mutations.ts
+++ b/apps/web/src/hooks/calendar/use-event-mutations.ts
@@ -49,7 +49,10 @@ export function useCreateEventMutation() {
         }
       },
       onSettled: () => {
-        queryClient.invalidateQueries({ queryKey });
+        // Path-level: the agenda view holds per-chunk events.list caches
+        // beyond the single key optimistically updated above; leaving them
+        // stale resurrects deleted events and hides created ones there.
+        queryClient.invalidateQueries({ queryKey: trpc.events.list.pathKey() });
       },
     }),
   );
@@ -109,7 +112,10 @@ export function useUpdateEventMutation() {
         }
       },
       onSettled: () => {
-        queryClient.invalidateQueries({ queryKey });
+        // Path-level: the agenda view holds per-chunk events.list caches
+        // beyond the single key optimistically updated above; leaving them
+        // stale resurrects deleted events and hides created ones there.
+        queryClient.invalidateQueries({ queryKey: trpc.events.list.pathKey() });
       },
     }),
   );
@@ -149,7 +155,10 @@ export function useDeleteEventMutation() {
         }
       },
       onSettled: () => {
-        queryClient.invalidateQueries({ queryKey });
+        // Path-level: the agenda view holds per-chunk events.list caches
+        // beyond the single key optimistically updated above; leaving them
+        // stale resurrects deleted events and hides created ones there.
+        queryClient.invalidateQueries({ queryKey: trpc.events.list.pathKey() });
       },
     }),
   );

--- a/apps/web/src/hooks/calendar/use-events.ts
+++ b/apps/web/src/hooks/calendar/use-events.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { DisplayItem, createEventDisplayItem } from "@/lib/display-item";
+import { createEventDisplayItem } from "@/lib/display-item";
 import { RouterOutputs } from "@/lib/trpc";
 import { useTRPC } from "@/lib/trpc/client";
 import { useCalendarStore } from "@/providers/calendar-store-provider";
@@ -28,6 +28,25 @@ export function useEventQueryParams() {
   return { timeMin, timeMax, defaultTimeZone, queryKey };
 }
 
+export function useSelectDisplayItems() {
+  "use memo";
+
+  const defaultTimeZone = useDefaultTimeZone();
+
+  return React.useCallback(
+    (data: RouterOutputs["events"]["list"]) => {
+      if (!data.events) {
+        return [];
+      }
+
+      return data.events.map((event) =>
+        createEventDisplayItem(event, defaultTimeZone),
+      );
+    },
+    [defaultTimeZone],
+  );
+}
+
 export function useEventsForDisplay() {
   "use memo";
 
@@ -45,25 +64,18 @@ export function useEventsForDisplay() {
   //   [defaultTimeZone],
   // );
 
+  const selectDisplayItems = useSelectDisplayItems();
+
   const select = React.useCallback(
     (data: RouterOutputs["events"]["list"]) => {
-      if (!data.events) {
-        return {
-          events: [],
-          recurringMasterEvents: {},
-        };
-      }
-
-      const events: DisplayItem[] = data.events.map((event) =>
-        createEventDisplayItem(event, defaultTimeZone),
-      );
+      const events = selectDisplayItems(data);
       // events.push(...mockItems);
       return {
         events,
         recurringMasterEvents: data.recurringMasterEvents,
       };
     },
-    [defaultTimeZone],
+    [selectDisplayItems],
   );
 
   const { data } = useQuery(

--- a/apps/web/src/store/slices/view-slice.ts
+++ b/apps/web/src/store/slices/view-slice.ts
@@ -90,7 +90,27 @@ export const createViewSlice: StateCreator<
 
   // Actions
   setCalendarView: (view) =>
-    set({ calendarView: view }, undefined, "view/setCalendarView"),
+    set(
+      (state) => {
+        // Agenda scrolling moves currentDate with keepTimeRange, so the
+        // shared range can be left far from currentDate. Re-anchor it on
+        // view switches — week/month mount around currentDate and would
+        // otherwise render blank until the next navigation.
+        const timeMin = calculateStart(state.currentDate);
+        const timeMax = calculateEnd(state.currentDate);
+
+        if (
+          Temporal.PlainDate.compare(state.timeMin, timeMin) === 0 &&
+          Temporal.PlainDate.compare(state.timeMax, timeMax) === 0
+        ) {
+          return { calendarView: view };
+        }
+
+        return { calendarView: view, timeMin, timeMax };
+      },
+      undefined,
+      "view/setCalendarView",
+    ),
 
   setCurrentDate: (date, options) =>
     set(

--- a/apps/web/src/store/slices/view-slice.ts
+++ b/apps/web/src/store/slices/view-slice.ts
@@ -49,7 +49,10 @@ export interface ViewSlice {
 
   // Actions
   setCalendarView: (view: CalendarView) => void;
-  setCurrentDate: (date: Temporal.PlainDate) => void;
+  setCurrentDate: (
+    date: Temporal.PlainDate,
+    options?: { keepTimeRange?: boolean },
+  ) => void;
   navigateTo: (date: Temporal.PlainDate) => void;
   setVisibleRange: (
     range: { start: Temporal.PlainDate; end: Temporal.PlainDate } | null,
@@ -89,11 +92,15 @@ export const createViewSlice: StateCreator<
   setCalendarView: (view) =>
     set({ calendarView: view }, undefined, "view/setCalendarView"),
 
-  setCurrentDate: (date) =>
+  setCurrentDate: (date, options) =>
     set(
       (state) => {
         if (Temporal.PlainDate.compare(state.currentDate, date) === 0) {
           return state;
+        }
+
+        if (options?.keepTimeRange) {
+          return { currentDate: date };
         }
 
         const timeMin = calculateStart(date);

--- a/packages/api/src/utils/accounts.ts
+++ b/packages/api/src/utils/accounts.ts
@@ -5,7 +5,7 @@ async function withAccessToken(account: Account, headers: Headers) {
   const { accessToken } = await auth.api.getAccessToken({
     body: {
       providerId: account.providerId,
-      accountId: account.id,
+      accountId: account.accountId,
       userId: account.userId,
     },
     headers,


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an infinite agenda view with virtualized day groups, chunked loading, and smooth scrolling for fast navigation across long timelines. Improves performance and keeps the UI responsive while browsing past and future items.

- New Features
  - Infinite agenda with virtualized day groups using `@tanstack/react-virtual`, scroll anchoring compensation, and WebKit fling handling.
  - Chunked event loading (60-day chunks, max 12) with 2-chunk prefetch and runway-based edge auto-extension; includes `scrollyfills` and `temporal-polyfill`.
  - Scroll updates the selected date; navigation jumps to target dates with a post-layout correction pass.
  - Shared `useProcessedDisplayItems` for optimistic updates and past/hidden filtering; agenda now fetches and persists chunk events and recurring masters to Dexie, while grid views mount the shared query only when active to avoid duplicate work.

- Bug Fixes
  - After create/update/delete, invalidate `events.list` path-level caches in `@tanstack/react-query` so chunked agenda data stays fresh.
  - `setCurrentDate` supports keepTimeRange; switching views re-anchors the global range to `currentDate` to avoid blank screens.
  - Fix access token fetch to use `account.accountId`.
  - Minor: `.gitignore` additions; `AgendaViewDay` now renders provided items without extra filtering.

<sup>Written for commit 73c24984c0a3edf4cef67097205baf99d7b7b5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/analogdotnow/Analog/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

