### PR TITLE
fix(providers): ensure complete event range is read

### DIFF
--- a/packages/providers/src/calendars/google-calendar/events/index.ts
+++ b/packages/providers/src/calendars/google-calendar/events/index.ts
@@ -41,23 +41,33 @@ export class GoogleCalendarEvents implements CalendarProviderEvents {
     timeZone,
   }: CalendarProviderEventsListOptions) {
     return this.withErrorHandler("events.list", async () => {
-      const { items } = await this.client.events.list({
-        calendarId: calendar.id,
-        timeMin: timeMin.withTimeZone("UTC").toInstant().toString(),
-        timeMax: timeMax.withTimeZone("UTC").toInstant().toString(),
-        singleEvents: true,
-        orderBy: "startTime",
-        maxResults: MAX_EVENTS_PER_CALENDAR,
-      });
+      const listPage = async (pageToken?: string): Promise<CalendarEvent[]> => {
+        const { items, nextPageToken } = await this.client.events.list({
+          calendarId: calendar.id,
+          timeMin: timeMin.withTimeZone("UTC").toInstant().toString(),
+          timeMax: timeMax.withTimeZone("UTC").toInstant().toString(),
+          singleEvents: true,
+          orderBy: "startTime",
+          maxResults: MAX_EVENTS_PER_CALENDAR,
+          pageToken,
+        });
 
-      const events: CalendarEvent[] =
-        items?.map((event) =>
+        const events = (items ?? []).map((event) =>
           parseGoogleCalendarEvent({
             calendar,
             event,
             defaultTimeZone: timeZone ?? "UTC",
           }),
-        ) ?? [];
+        );
+
+        if (!nextPageToken) {
+          return events;
+        }
+
+        return events.concat(await listPage(nextPageToken));
+      };
+
+      const events = await listPage();
 
       const instances = events.filter((e) => e.recurringEventId);
       const masters = new Set<string>([]);

--- a/packages/providers/src/calendars/microsoft-calendar/events/index.ts
+++ b/packages/providers/src/calendars/microsoft-calendar/events/index.ts
@@ -3,14 +3,16 @@ import type {
   DefaultCalendarCreateEventInput,
   DefaultCalendarDeleteEventInput,
   DefaultCalendarGetEventInput,
+  DefaultCalendarListCalendarViewInput,
   DefaultCalendarListEventInput,
   DefaultCalendarUpdateEventInput,
   DeltaCollectionResponse,
   Event as MicrosoftEvent,
+  EventCollectionResponse,
   MicrosoftCalendar,
 } from "@analog/microsoft-calendar";
 
-import type { CalendarEventSyncItem } from "../../../interfaces";
+import type { CalendarEvent, CalendarEventSyncItem } from "../../../interfaces";
 import type {
   CalendarProviderEvents,
   CalendarProviderEventsCreateOptions,
@@ -62,6 +64,8 @@ export class MicrosoftCalendarEvents implements CalendarProviderEvents {
     const calendarView = this.client.users.calendars.calendarView;
 
     return {
+      list: (params: DefaultCalendarListCalendarViewInput) =>
+        calendarView.list({ ...params, calendarId }),
       delta: (params: DefaultCalendarCalendarViewDeltaInput) =>
         calendarView.delta({ ...params, calendarId }),
     };
@@ -77,22 +81,65 @@ export class MicrosoftCalendarEvents implements CalendarProviderEvents {
       const startTime = timeMin.withTimeZone("UTC").toInstant().toString();
       const endTime = timeMax.withTimeZone("UTC").toInstant().toString();
 
-      const filter = `start/dateTime ge '${startTime}' and end/dateTime le '${endTime}'`;
       const headers = { Prefer: `outlook.timezone="${timeZone ?? "UTC"}"` };
 
-      const response = await this.eventsFor(calendar.id).list({
-        userId: "me",
-        filter,
-        orderby: ["start/dateTime"],
-        top: MAX_EVENTS_PER_CALENDAR,
-        headers,
-      });
+      const listPages = async (nextLink?: string): Promise<CalendarEvent[]> => {
+        if (!nextLink) {
+          const response = await this.calendarViewFor(calendar.id).list({
+            userId: "me",
+            startDateTime: startTime,
+            endDateTime: endTime,
+            orderby: ["start/dateTime"],
+            top: MAX_EVENTS_PER_CALENDAR,
+            headers,
+          });
 
-      const events = (response.value ?? []).map((event) =>
-        parseMicrosoftEvent({ event, calendar }),
+          const events = (response.value ?? []).map((event) =>
+            parseMicrosoftEvent({ event, calendar }),
+          );
+
+          if (!response["@odata.nextLink"]) {
+            return events;
+          }
+
+          return events.concat(await listPages(response["@odata.nextLink"]));
+        }
+
+        const page = await this.client.get<EventCollectionResponse>(
+          nextLink,
+          undefined,
+          undefined,
+          headers,
+        );
+
+        const events = (page.value ?? []).map((event) =>
+          parseMicrosoftEvent({ event, calendar }),
+        );
+
+        if (!page["@odata.nextLink"]) {
+          return events;
+        }
+
+        return events.concat(await listPages(page["@odata.nextLink"]));
+      };
+
+      const events = await listPages();
+
+      const recurringEventIds = new Set<string>();
+
+      for (const event of events) {
+        if (event.recurringEventId) {
+          recurringEventIds.add(event.recurringEventId);
+        }
+      }
+
+      const recurringMasterEvents = await Promise.all(
+        Array.from(recurringEventIds).map((eventId) =>
+          this.get({ calendar, eventId, timeZone }),
+        ),
       );
 
-      return { events, recurringMasterEvents: [] };
+      return { events, recurringMasterEvents };
     });
   }
 

--- a/packages/providers/src/calendars/microsoft-calendar/events/utils.ts
+++ b/packages/providers/src/calendars/microsoft-calendar/events/utils.ts
@@ -93,6 +93,7 @@ export function parseMicrosoftEvent({
     },
     readOnly: calendar.readOnly,
     conference: parseMicrosoftConference(event),
+    recurringEventId: event.seriesMasterId ?? undefined,
     ...(responseStatus ? { response: { status: responseStatus } } : {}),
     ...(event.createdDateTime
       ? { createdAt: Temporal.Instant.from(event.createdDateTime) }


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads the full event range for Google and Microsoft calendar providers by adding pagination and proper recurrence handling. Fixes missed events when the time window spans multiple pages.

- **Bug Fixes**
  - Google Calendar: paginate `events.list` using `nextPageToken` to fetch all pages within the requested range.
  - Microsoft 365: use CalendarView with `startDateTime`/`endDateTime`, page via `@odata.nextLink`, set `recurringEventId` from `seriesMasterId`, and load recurring master events; keeps timezone via `Prefer` header from `@analog/microsoft-calendar`.

<sup>Written for commit d28cf3341995504820e168bb2e4bcc8aac08e643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/analogdotnow/Analog/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

