### PR TITLE
feat(microsoft): add microsoft people sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -439,6 +439,15 @@
         "typescript": "catalog:",
       },
     },
+    "packages/microsoft-people": {
+      "name": "@analog/microsoft-people",
+      "version": "0.0.1-alpha.0",
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "@types/node": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/providers": {
       "name": "@repo/providers",
       "version": "0.1.0",
@@ -604,6 +613,8 @@
     "@analog/meeting-links": ["@analog/meeting-links@workspace:packages/meeting-links"],
 
     "@analog/microsoft-calendar": ["@analog/microsoft-calendar@workspace:packages/microsoft-calendar"],
+
+    "@analog/microsoft-people": ["@analog/microsoft-people@workspace:packages/microsoft-people"],
 
     "@ariakit/components": ["@ariakit/components@0.1.2", "", { "dependencies": { "@ariakit/store": "0.1.2", "@ariakit/utils": "0.1.2" } }, "sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw=="],
 

--- a/packages/microsoft-people/package.json
+++ b/packages/microsoft-people/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@analog/microsoft-people",
+  "version": "0.0.1-alpha.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/microsoft-people/src/client.ts
+++ b/packages/microsoft-people/src/client.ts
@@ -1,0 +1,163 @@
+import { APIError, ConnectionError, TimeoutError } from "./error";
+import type { QueryParams, RequestHeaders } from "./interfaces";
+import { Users } from "./users";
+
+export class MicrosoftPeople {
+  private static readonly BASE_URL = "https://graph.microsoft.com/v1.0";
+  private static readonly ORIGIN_URL = "https://graph.microsoft.com";
+
+  public readonly users: Users;
+
+  constructor(private readonly accessToken: string) {
+    this.users = new Users(this);
+  }
+
+  private buildUrl(path: string, params?: QueryParams) {
+    // Microsoft Graph absolute URLs (@odata.nextLink) are used as-is.
+    // A userId of "me" maps to the /me alias; "me" is never a valid user id
+    // or userPrincipalName, so the rewrite cannot collide with a real user.
+    const url = new URL(
+      path.startsWith("https://")
+        ? path
+        : `${MicrosoftPeople.BASE_URL}${path.startsWith("/users/me/") ? path.slice("/users".length) : path}`,
+    );
+
+    if (url.origin !== MicrosoftPeople.ORIGIN_URL) {
+      throw new Error("Absolute URLs must use the Microsoft Graph origin");
+    }
+
+    if (!params) {
+      return url;
+    }
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) {
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        url.searchParams.set(key, value.map((item) => String(item)).join(","));
+        continue;
+      }
+
+      url.searchParams.set(key, String(value));
+    }
+
+    return url;
+  }
+
+  private buildHeaders(headers?: RequestHeaders) {
+    return {
+      Authorization: `Bearer ${this.accessToken}`,
+      ...headers,
+    };
+  }
+
+  private async fetch(url: URL, init: RequestInit): Promise<Response> {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      MicrosoftPeople.throwTransportError(error, init.signal);
+    }
+  }
+
+  private static throwTransportError(
+    error: unknown,
+    signal?: AbortSignal | null,
+  ): never {
+    if (!(error instanceof Error)) {
+      if (signal?.aborted && error === signal.reason) {
+        throw error;
+      }
+
+      throw new ConnectionError(undefined, error);
+    }
+
+    // Caller-initiated aborts propagate as-is; AbortSignal.timeout() aborts
+    // map to TimeoutError, transport failures (DNS, reset) to ConnectionError.
+    if (error.name === "AbortError") {
+      throw error;
+    }
+
+    if (error.name === "TimeoutError") {
+      throw new TimeoutError(error.message);
+    }
+
+    if (signal?.aborted && error === signal.reason) {
+      throw error;
+    }
+
+    throw new ConnectionError(error.message, error);
+  }
+
+  private async parseResponse(response: Response) {
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw APIError.fromResponse(response, text);
+    }
+
+    if (!text) {
+      throw new APIError(
+        response.status,
+        undefined,
+        "Empty response body",
+        response.headers,
+      );
+    }
+
+    return JSON.parse(text);
+  }
+
+  private async parseText(response: Response): Promise<string> {
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw APIError.fromResponse(response, text);
+    }
+
+    return text;
+  }
+
+  async get<T>(
+    path: string,
+    params?: QueryParams,
+    signal?: AbortSignal,
+    headers?: RequestHeaders,
+  ): Promise<T> {
+    const response = await this.fetch(this.buildUrl(path, params), {
+      method: "GET",
+      headers: this.buildHeaders(headers),
+      signal,
+    });
+
+    return this.parseResponse(response);
+  }
+
+  async number(
+    path: string,
+    params?: QueryParams,
+    signal?: AbortSignal,
+    headers?: RequestHeaders,
+  ): Promise<number> {
+    const response = await this.fetch(this.buildUrl(path, params), {
+      method: "GET",
+      headers: this.buildHeaders(headers),
+      signal,
+    });
+
+    const text = await this.parseText(response);
+    const value = Number(text);
+
+    if (!text || !Number.isFinite(value)) {
+      throw new APIError(
+        response.status,
+        undefined,
+        "Expected a numeric response body",
+        response.headers,
+      );
+    }
+
+    return value;
+  }
+}

--- a/packages/microsoft-people/src/client.ts
+++ b/packages/microsoft-people/src/client.ts
@@ -19,7 +19,7 @@ export class MicrosoftPeople {
     const url = new URL(
       path.startsWith("https://")
         ? path
-        : `${MicrosoftPeople.BASE_URL}${path.startsWith("/users/me/") ? path.slice("/users".length) : path}`,
+        : `${MicrosoftPeople.BASE_URL}${path.replace(/^\/users\/me(?=\/|$)/, "/me")}`,
     );
 
     if (url.origin !== MicrosoftPeople.ORIGIN_URL) {
@@ -90,8 +90,19 @@ export class MicrosoftPeople {
     throw new ConnectionError(error.message, error);
   }
 
-  private async parseResponse(response: Response) {
-    const text = await response.text();
+  private async readResponseText(
+    response: Response,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    try {
+      return await response.text();
+    } catch (error) {
+      MicrosoftPeople.throwTransportError(error, signal);
+    }
+  }
+
+  private async parseResponse(response: Response, signal?: AbortSignal) {
+    const text = await this.readResponseText(response, signal);
 
     if (!response.ok) {
       throw APIError.fromResponse(response, text);
@@ -109,8 +120,11 @@ export class MicrosoftPeople {
     return JSON.parse(text);
   }
 
-  private async parseText(response: Response): Promise<string> {
-    const text = await response.text();
+  private async parseText(
+    response: Response,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const text = await this.readResponseText(response, signal);
 
     if (!response.ok) {
       throw APIError.fromResponse(response, text);
@@ -131,7 +145,7 @@ export class MicrosoftPeople {
       signal,
     });
 
-    return this.parseResponse(response);
+    return this.parseResponse(response, signal);
   }
 
   async number(
@@ -146,10 +160,10 @@ export class MicrosoftPeople {
       signal,
     });
 
-    const text = await this.parseText(response);
+    const text = await this.parseText(response, signal);
     const value = Number(text);
 
-    if (!text || !Number.isFinite(value)) {
+    if (!text.trim() || !Number.isFinite(value)) {
       throw new APIError(
         response.status,
         undefined,

--- a/packages/microsoft-people/src/error.ts
+++ b/packages/microsoft-people/src/error.ts
@@ -1,0 +1,244 @@
+export interface ODataError {
+  error: ODataMainError;
+  [key: string]: unknown;
+}
+
+export interface ODataMainError {
+  code: string;
+  message: string;
+  target?: string | null;
+  details?: ODataErrorDetail[];
+  innerError?: ODataInnerError;
+  [key: string]: unknown;
+}
+
+export interface ODataErrorDetail {
+  code: string;
+  message: string;
+  target?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ODataInnerError {
+  code?: string;
+  "client-request-id"?: string;
+  date?: string;
+  "request-id"?: string;
+  innerError?: ODataInnerError;
+  [key: string]: unknown;
+}
+
+export class APIError<
+  TStatus extends number | undefined = number | undefined,
+  THeaders extends Headers | undefined = Headers | undefined,
+  TError extends ODataError | undefined = ODataError | undefined,
+> extends Error {
+  /** HTTP status for the response that caused the error */
+  readonly status: TStatus;
+  /** HTTP headers for the response that caused the error */
+  readonly headers: THeaders;
+  /** JSON body of the response that caused the error */
+  readonly error: TError;
+
+  constructor(
+    status: TStatus,
+    error: TError,
+    message: string | undefined,
+    headers: THeaders,
+  ) {
+    super(`${APIError.makeMessage(status, error, message)}`);
+    this.status = status;
+    this.headers = headers;
+    this.error = error;
+  }
+
+  private static makeMessage(
+    status: number | undefined,
+    error: ODataError | undefined,
+    message: string | undefined,
+  ) {
+    if (error) {
+      if (status) {
+        return `${status} ${error.error.message}`;
+      }
+
+      return error.error.message;
+    }
+
+    if (status && message) {
+      return `${status} ${message}`;
+    }
+    if (status) {
+      return `${status} status code (no body)`;
+    }
+    if (message) {
+      return message;
+    }
+    return "(no status code or body)";
+  }
+
+  static from(
+    status: number,
+    error: ODataError | undefined,
+    message: string | undefined,
+    headers: Headers,
+  ): APIError {
+    if (status === 400) {
+      return new BadRequestError(status, error, message, headers);
+    }
+
+    if (status === 401) {
+      return new AuthenticationError(status, error, message, headers);
+    }
+
+    if (status === 403) {
+      return new PermissionDeniedError(status, error, message, headers);
+    }
+
+    if (status === 404) {
+      return new NotFoundError(status, error, message, headers);
+    }
+
+    if (status === 409) {
+      return new ConflictError(status, error, message, headers);
+    }
+
+    if (status === 422) {
+      return new UnprocessableEntityError(status, error, message, headers);
+    }
+
+    if (status === 429) {
+      return new RateLimitError(status, error, message, headers);
+    }
+
+    if (status === 502) {
+      return new BadGatewayError(status, error, message, headers);
+    }
+
+    if (status === 503) {
+      return new ServiceUnavailableError(status, error, message, headers);
+    }
+
+    if (status === 504) {
+      return new GatewayTimeoutError(status, error, message, headers);
+    }
+
+    if (status >= 500) {
+      return new InternalServerError(status, error, message, headers);
+    }
+
+    if (status === 402) {
+      return new PaymentRequiredError(status, error, message, headers);
+    }
+
+    if (status === 405) {
+      return new MethodNotAllowedError(status, error, message, headers);
+    }
+
+    if (status === 408) {
+      return new RequestTimeoutError(status, error, message, headers);
+    }
+
+    if (status === 410) {
+      return new GoneError(status, error, message, headers);
+    }
+
+    if (status === 413) {
+      return new PayloadTooLargeError(status, error, message, headers);
+    }
+
+    if (status === 415) {
+      return new UnsupportedMediaTypeError(status, error, message, headers);
+    }
+
+    if (status === 428) {
+      return new PreconditionRequiredError(status, error, message, headers);
+    }
+
+    if (status === 451) {
+      return new LegalReasonsError(status, error, message, headers);
+    }
+
+    return new APIError(status, error, message, headers);
+  }
+
+  static fromResponse(response: Response, text: string) {
+    return APIError.from(
+      response.status,
+      parseErrorBody(text),
+      response.statusText,
+      response.headers,
+    );
+  }
+}
+
+function parseErrorBody(text: string): ODataError | undefined {
+  try {
+    const error: ODataError = JSON.parse(text);
+
+    if (!error.error.code) {
+      return undefined;
+    }
+
+    if (!error.error.message) {
+      return undefined;
+    }
+
+    return error;
+  } catch {
+    return undefined;
+  }
+}
+
+export class TimeoutError extends APIError<undefined, undefined> {
+  constructor(message?: string) {
+    super(undefined, undefined, message ?? "Request timed out.", undefined);
+  }
+}
+
+export class ConnectionError extends APIError<undefined, undefined> {
+  constructor(message?: string, cause?: unknown) {
+    super(undefined, undefined, message ?? "Connection error.", undefined);
+    this.cause = cause;
+  }
+}
+
+export class BadRequestError extends APIError<400, Headers> {}
+
+export class AuthenticationError extends APIError<401, Headers> {}
+
+export class PermissionDeniedError extends APIError<403, Headers> {}
+
+export class NotFoundError extends APIError<404, Headers> {}
+
+export class ConflictError extends APIError<409, Headers> {}
+
+export class UnprocessableEntityError extends APIError<422, Headers> {}
+
+export class RateLimitError extends APIError<429, Headers> {}
+
+export class InternalServerError<
+  TStatus extends number = number,
+> extends APIError<TStatus, Headers> {}
+
+export class BadGatewayError extends InternalServerError<502> {}
+
+export class ServiceUnavailableError extends InternalServerError<503> {}
+
+export class GatewayTimeoutError extends InternalServerError<504> {}
+
+export class PaymentRequiredError extends APIError<402, Headers> {}
+
+export class MethodNotAllowedError extends APIError<405, Headers> {}
+
+export class RequestTimeoutError extends APIError<408, Headers> {}
+
+export class GoneError extends APIError<410, Headers> {}
+
+export class PayloadTooLargeError extends APIError<413, Headers> {}
+
+export class UnsupportedMediaTypeError extends APIError<415, Headers> {}
+
+export class PreconditionRequiredError extends APIError<428, Headers> {}
+
+export class LegalReasonsError extends APIError<451, Headers> {}

--- a/packages/microsoft-people/src/index.ts
+++ b/packages/microsoft-people/src/index.ts
@@ -1,0 +1,4 @@
+export { MicrosoftPeople } from "./client";
+export * from "./error";
+export type * from "./interfaces";
+export type * from "./users/people/interfaces";

--- a/packages/microsoft-people/src/interfaces.ts
+++ b/packages/microsoft-people/src/interfaces.ts
@@ -1,0 +1,149 @@
+export type QueryParamItem = string | number | boolean;
+export type QueryParamValue =
+  | QueryParamItem
+  | QueryParamItem[]
+  | null
+  | undefined;
+export type QueryParams = Record<string, QueryParamValue>;
+export type RequestHeaders = Record<string, string>;
+
+export interface MicrosoftPeopleRequestOptions {
+  signal?: AbortSignal;
+  headers?: RequestHeaders;
+}
+
+export interface ListMoreInput extends MicrosoftPeopleRequestOptions {
+  nextLink: string;
+}
+
+export interface CollectionResponse<T> {
+  value?: T[];
+  "@odata.nextLink"?: string | null;
+  [key: string]: unknown;
+}
+
+export type ODataCountResponse = number;
+
+export interface Entity {
+  id?: string;
+  [key: string]: unknown;
+}
+
+export interface Location {
+  address?: PhysicalAddress;
+  coordinates?: OutlookGeoCoordinates;
+  displayName?: string | null;
+  locationEmailAddress?: string | null;
+  locationType?: LocationType;
+  locationUri?: string | null;
+  uniqueId?: string | null;
+  uniqueIdType?: LocationUniqueIdType;
+  [key: string]: unknown;
+}
+
+export type LocationType =
+  | "default"
+  | "conferenceRoom"
+  | "homeAddress"
+  | "businessAddress"
+  | "geoCoordinates"
+  | "streetAddress"
+  | "hotel"
+  | "restaurant"
+  | "localBusiness"
+  | "postalAddress";
+
+export type LocationUniqueIdType =
+  | "unknown"
+  | "locationStore"
+  | "directory"
+  | "private"
+  | "bing";
+
+export interface OutlookGeoCoordinates {
+  accuracy?: number | null;
+  altitude?: number | null;
+  altitudeAccuracy?: number | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  [key: string]: unknown;
+}
+
+export interface Person extends Entity {
+  birthday?: string | null;
+  companyName?: string | null;
+  department?: string | null;
+  displayName?: string | null;
+  givenName?: string | null;
+  imAddress?: string | null;
+  isFavorite?: boolean | null;
+  jobTitle?: string | null;
+  officeLocation?: string | null;
+  personNotes?: string | null;
+  personType?: PersonType;
+  phones?: Phone[];
+  postalAddresses?: Location[];
+  profession?: string | null;
+  scoredEmailAddresses?: ScoredEmailAddress[];
+  surname?: string | null;
+  userPrincipalName?: string | null;
+  websites?: Website[];
+  yomiCompany?: string | null;
+  [key: string]: unknown;
+}
+
+export interface PersonCollectionResponse extends CollectionResponse<Person> {}
+
+export interface PersonType {
+  class?: string | null;
+  subclass?: string | null;
+  [key: string]: unknown;
+}
+
+export interface Phone {
+  language?: string | null;
+  number?: string | null;
+  region?: string | null;
+  type?: PhoneType;
+  [key: string]: unknown;
+}
+
+export type PhoneType =
+  | "home"
+  | "business"
+  | "mobile"
+  | "other"
+  | "assistant"
+  | "homeFax"
+  | "businessFax"
+  | "otherFax"
+  | "pager"
+  | "radio";
+
+export interface PhysicalAddress {
+  city?: string | null;
+  countryOrRegion?: string | null;
+  postalCode?: string | null;
+  state?: string | null;
+  street?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ScoredEmailAddress {
+  address?: string | null;
+  itemId?: string | null;
+  relevanceScore?: number | null;
+  selectionLikelihood?: SelectionLikelihoodInfo;
+  [key: string]: unknown;
+}
+
+export type SelectionLikelihoodInfo = "notSpecified" | "high";
+
+export interface Website {
+  address?: string | null;
+  displayName?: string | null;
+  type?: WebsiteType;
+  [key: string]: unknown;
+}
+
+export type WebsiteType = "other" | "home" | "work" | "blog" | "profile";

--- a/packages/microsoft-people/src/interfaces.ts
+++ b/packages/microsoft-people/src/interfaces.ts
@@ -19,6 +19,7 @@ export interface ListMoreInput extends MicrosoftPeopleRequestOptions {
 export interface CollectionResponse<T> {
   value?: T[];
   "@odata.nextLink"?: string | null;
+  "@odata.count"?: number;
   [key: string]: unknown;
 }
 

--- a/packages/microsoft-people/src/users/index.ts
+++ b/packages/microsoft-people/src/users/index.ts
@@ -1,0 +1,1 @@
+export * from "./users";

--- a/packages/microsoft-people/src/users/people/index.ts
+++ b/packages/microsoft-people/src/users/people/index.ts
@@ -1,0 +1,1 @@
+export * from "./people";

--- a/packages/microsoft-people/src/users/people/interfaces.ts
+++ b/packages/microsoft-people/src/users/people/interfaces.ts
@@ -1,0 +1,37 @@
+import type {
+  MicrosoftPeopleRequestOptions,
+  ODataCountResponse,
+  Person,
+  PersonCollectionResponse,
+} from "../../interfaces";
+
+export interface ListPersonInput extends MicrosoftPeopleRequestOptions {
+  userId: string;
+  top?: number;
+  skip?: number;
+  search?: string;
+  filter?: string;
+  count?: boolean;
+  orderby?: string[];
+  select?: string[];
+  expand?: string[];
+}
+
+export type ListPersonResponse = PersonCollectionResponse;
+
+export interface GetCountInput extends MicrosoftPeopleRequestOptions {
+  userId: string;
+  search?: string;
+  filter?: string;
+}
+
+export type GetCountResponse = ODataCountResponse;
+
+export interface GetPersonInput extends MicrosoftPeopleRequestOptions {
+  userId: string;
+  personId: string;
+  select?: string[];
+  expand?: string[];
+}
+
+export type GetPersonResponse = Person;

--- a/packages/microsoft-people/src/users/people/people.ts
+++ b/packages/microsoft-people/src/users/people/people.ts
@@ -1,0 +1,65 @@
+import type { MicrosoftPeople } from "../../client";
+import type { ListMoreInput } from "../../interfaces";
+import type {
+  GetCountInput,
+  GetCountResponse,
+  GetPersonInput,
+  GetPersonResponse,
+  ListPersonInput,
+  ListPersonResponse,
+} from "./interfaces";
+
+export class People {
+  constructor(private readonly client: MicrosoftPeople) {}
+
+  async list(params: ListPersonInput): Promise<ListPersonResponse> {
+    return this.client.get<ListPersonResponse>(
+      `/users/${encodeURIComponent(params.userId)}/people`,
+      {
+        $top: params.top,
+        $skip: params.skip,
+        $search: params.search,
+        $filter: params.filter,
+        $count: params.count,
+        $orderby: params.orderby,
+        $select: params.select,
+        $expand: params.expand,
+      },
+      params.signal,
+      params.headers,
+    );
+  }
+
+  async listMore(params: ListMoreInput): Promise<ListPersonResponse> {
+    return this.client.get<ListPersonResponse>(
+      params.nextLink,
+      undefined,
+      params.signal,
+      params.headers,
+    );
+  }
+
+  async $count(params: GetCountInput): Promise<GetCountResponse> {
+    return this.client.number(
+      `/users/${encodeURIComponent(params.userId)}/people/$count`,
+      {
+        $search: params.search,
+        $filter: params.filter,
+      },
+      params.signal,
+      params.headers,
+    );
+  }
+
+  async get(params: GetPersonInput): Promise<GetPersonResponse> {
+    return this.client.get<GetPersonResponse>(
+      `/users/${encodeURIComponent(params.userId)}/people/${encodeURIComponent(params.personId)}`,
+      {
+        $select: params.select,
+        $expand: params.expand,
+      },
+      params.signal,
+      params.headers,
+    );
+  }
+}

--- a/packages/microsoft-people/src/users/users.ts
+++ b/packages/microsoft-people/src/users/users.ts
@@ -1,0 +1,10 @@
+import type { MicrosoftPeople } from "../client";
+import { People } from "./people";
+
+export class Users {
+  public readonly people: People;
+
+  constructor(private readonly client: MicrosoftPeople) {
+    this.people = new People(client);
+  }
+}

--- a/packages/microsoft-people/tsconfig.json
+++ b/packages/microsoft-people/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@analog/microsoft-people`, a typed client for Microsoft Graph People to list, page, count, and fetch person details. Strengthens reliability with robust transport/API error handling and clear types.

- **New Features**
  - `MicrosoftPeople` client with `users.people`: `list`, `listMore(nextLink)`, `$count`, `get`.
  - Supports Graph params: `$top`, `$skip`, `$search`, `$filter`, `$count`, `$orderby`, `$select`, `$expand`.
  - Standardized errors (`APIError`, `AuthenticationError`, `RateLimitError`, `TimeoutError`, `ConnectionError`, etc.).
  - Request options support `AbortSignal` and custom headers; handles `userId: "me"` alias and validates absolute `@odata.nextLink` origins.

<sup>Written for commit 1a1250921d8c610c7ff1c8743dc1f224d235cd39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/analogdotnow/Analog/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

