### PR TITLE
fix(web): resolve drag and drop not working in month view

### DIFF
--- a/apps/web/src/components/calendar/event/draggable-month-event.tsx
+++ b/apps/web/src/components/calendar/event/draggable-month-event.tsx
@@ -21,7 +21,9 @@ import {
 import { getEventInForm } from "@/components/event-form/atoms/form";
 import { ContextMenuTrigger } from "@/components/ui/context-menu";
 import { EventDisplayItem } from "@/lib/display-item";
-import { useSetDraggingEventId } from "@/store/hooks";
+import { cn } from "@/lib/utils";
+import { useDraggingEventId, useSetDraggingEventId } from "@/store/hooks";
+import { DragPreviewPortal } from "./drag-preview-portal";
 
 interface GetColumnOffsetOptions {
   containerRef: React.RefObject<HTMLElement | null>;
@@ -148,6 +150,11 @@ export function DraggableMonthEvent({
 
   const { setIsDragging, moveEvent } = useEvent(item.event);
 
+  const eventElementRef = React.useRef<HTMLDivElement | null>(null);
+
+  const draggingEventId = useDraggingEventId();
+  const isDragging = draggingEventId === item.event.id;
+
   const originX = useMotionValue(0);
   const originY = useMotionValue(0);
   const relativeX = useMotionValue(0);
@@ -158,6 +165,14 @@ export function DraggableMonthEvent({
 
   const transform = useMotionTemplate`translate(${left}px,${top}px)`;
 
+  const grabOffsetX = React.useRef(0);
+  const grabOffsetY = React.useRef(0);
+
+  const previewX = useMotionValue(0);
+  const previewY = useMotionValue(0);
+  const previewWidth = useMotionValue(0);
+  const previewHeight = useMotionValue(0);
+
   const onDragStart = (e: PointerEvent, info: PanInfo) => {
     e.preventDefault();
 
@@ -165,10 +180,21 @@ export function DraggableMonthEvent({
       return;
     }
 
-    const rect = containerRef.current.getBoundingClientRect();
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const eventRect = eventElementRef.current!.getBoundingClientRect();
 
-    originX.set(info.point.x - info.offset.x - rect.left);
-    originY.set(info.point.y - info.offset.y - rect.top);
+    originX.set(info.point.x - info.offset.x - containerRect.left);
+    originY.set(info.point.y - info.offset.y - containerRect.top);
+    relativeX.set(info.point.x - containerRect.left);
+    relativeY.set(info.point.y - containerRect.top);
+
+    grabOffsetX.current = info.point.x - eventRect.left;
+    grabOffsetY.current = info.point.y - eventRect.top;
+
+    previewX.set(eventRect.left);
+    previewY.set(eventRect.top);
+    previewWidth.set(eventRect.width);
+    previewHeight.set(eventRect.height);
 
     setIsDragging(true);
   };
@@ -182,18 +208,19 @@ export function DraggableMonthEvent({
 
     relativeX.set(info.point.x - rect.left);
     relativeY.set(info.point.y - rect.top);
+
+    previewX.set(info.point.x - grabOffsetX.current);
+    previewY.set(info.point.y - grabOffsetY.current);
   };
 
   const onDragEnd = (_e: PointerEvent, info: PanInfo) => {
+    previewX.set(info.point.x - grabOffsetX.current);
+    previewY.set(info.point.y - grabOffsetY.current);
+
     setIsDragging(false);
 
     const columnOffset = getColumnOffset({ containerRef, info, columns });
     const deltaY = relativeY.get() - originY.get();
-
-    originX.set(0);
-    originY.set(0);
-    relativeX.set(0);
-    relativeY.set(0);
 
     moveEvent(deltaY, columnOffset);
   };
@@ -208,32 +235,48 @@ export function DraggableMonthEvent({
     originY,
     relativeX,
     relativeY,
-    // item.event.start,
-    // item.event.end,
+    item.event.start,
+    item.event.end,
   ]);
 
   return (
-    <motion.div className="size-full touch-none" style={{ transform, zIndex }}>
-      <EventContextMenu event={item.event}>
-        <ContextMenuTrigger>
-          <MonthEventItem
-            item={item}
-            isFirstDay={isFirstDay}
-            isLastDay={isLastDay}
-          >
-            {!item.event.readOnly ? (
-              <>
+    <>
+      {isDragging ? (
+        <DragPreviewPortal
+          item={item}
+          isAllDayItem
+          isFirstDay={isFirstDay}
+          isLastDay={isLastDay}
+          x={previewX}
+          y={previewY}
+          width={previewWidth}
+          height={previewHeight}
+        />
+      ) : null}
+      <motion.div
+        ref={eventElementRef}
+        className={cn("size-full touch-none", isDragging && "invisible")}
+        style={{ transform, zIndex }}
+      >
+        <EventContextMenu event={item.event}>
+          <ContextMenuTrigger>
+            <MonthEventItem
+              item={item}
+              isFirstDay={isFirstDay}
+              isLastDay={isLastDay}
+            >
+              {!item.event.readOnly ? (
                 <motion.div
                   className="absolute inset-x-0 inset-y-2 touch-none"
                   onPanStart={onDragStart}
                   onPan={onDrag}
                   onPanEnd={onDragEnd}
                 />
-              </>
-            ) : null}
-          </MonthEventItem>
-        </ContextMenuTrigger>
-      </EventContextMenu>
-    </motion.div>
+              ) : null}
+            </MonthEventItem>
+          </ContextMenuTrigger>
+        </EventContextMenu>
+      </motion.div>
+    </>
   );
 }

--- a/apps/web/src/components/calendar/month-view/infinite-month-view.tsx
+++ b/apps/web/src/components/calendar/month-view/infinite-month-view.tsx
@@ -29,7 +29,10 @@ export function InfiniteMonthView({
   const grid = useMonthViewGridLayout();
 
   return (
-    <ContainerProvider containerRef={containerRef} view={view}>
+    <ContainerProvider
+      containerRef={containerRef}
+      view={{ ...view, rows: rows.total }}
+    >
       <div
         ref={scrollRef}
         data-slot="infinite-month-view"


### PR DESCRIPTION
<!--
Thanks for contributing to analog.now!
Please follow the template below.
Keep it clear and concise. Remove any section that doesn’t apply.
-->

## Description

Briefly describe what you did and why.

## Screenshots / Recordings

Add screenshots or recordings here to help reviewers understand your changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] UI/UX update
- [ ] Docs update
- [ ] Refactor / Cleanup

## Related Areas

- [ ] Authentication
- [ ] Calendar UI
- [ ] Data/API
- [ ] Docs

## Testing

- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Checklist

- [ ] I’ve read the [CONTRIBUTING](https://github.com/analogdotnow/Analog/blob/main/CONTRIBUTING.md) guide
- [ ] My code works and is understandable and follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] Any dependent changes are merged and published

## Notes

(Optional) Add anything else you'd like to share.

_By submitting, I confirm I understand and stand behind this code. If AI was used, I’ve reviewed and verified everything myself._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken drag-and-drop in the Month view by adding a drag preview and correct pointer offset tracking, so events can be moved across days/weeks reliably.

- **Bug Fixes**
  - Added `DragPreviewPortal` and hid the original element while dragging for smooth visuals.
  - Tracked grab offsets relative to the event rect to keep the preview under the cursor.
  - Calculated positions using container and event bounds; updated preview x/y/size during drag.
  - Used `useDraggingEventId` to toggle drag state and `moveEvent` with proper column offsets.
  - Passed `rows.total` into `ContainerProvider` to align grid math and enable correct drops across rows.

<sup>Written for commit d57de6f1e28fde9f37f7426e0a3ade4ca1e628cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/analogdotnow/Analog/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

